### PR TITLE
Update _parcel_aux_numba.py float dtype

### DIFF
--- a/pyrcel/_parcel_aux_numba.py
+++ b/pyrcel/_parcel_aux_numba.py
@@ -5,7 +5,7 @@ from numba.pycc import CC
 import pyrcel.constants as c
 
 ## Define double DTYPE
-DTYPE = np.float
+DTYPE = np.float64
 
 PI = 3.14159265358979323846264338328
 N_STATE_VARS = c.N_STATE_VARS


### PR DESCRIPTION
As of numpy v1.20, the dtype np.float points to python's native float type. We want to use the original 64-bit float from numpy, so we exclusively name it.