### PR TITLE
Fix typo in acc. mode conc. of Whitby 1978 clean marine dist.

### DIFF
--- a/pyrcel/distributions.py
+++ b/pyrcel/distributions.py
@@ -275,7 +275,7 @@ whitby_distributions = {
     #        mu = micron, N = cm**-3
     "marine": [
         Lognorm(0.01 / 2.0, 1.6, 340.0),
-        Lognorm(0.07 / 2.0, 2.0, 6.0),
+        Lognorm(0.07 / 2.0, 2.0, 60.0),
         Lognorm(0.62 / 2.0, 2.7, 3.1),
     ],
     "continental": [


### PR DESCRIPTION
Using the pre-defined Whitby 1978 clean marine distribution I came across this typo in the number concentration of the accumulation mode.