### PR TITLE
clarify ss% documentation

### DIFF
--- a/docs/examples/basic_run.ipynb
+++ b/docs/examples/basic_run.ipynb
@@ -63,7 +63,7 @@
    "source": [
     "P0 = 77500. # Pressure, Pa\n",
     "T0 = 274.   # Temperature, K\n",
-    "S0 = -0.02  # Supersaturation, 1-RH (98% here)"
+    "S0 = -0.02  # Supersaturation, RH-1 (with RH = 98% here)"
    ],
    "outputs": [],
    "metadata": {

--- a/docs/examples/basic_run.rst
+++ b/docs/examples/basic_run.rst
@@ -35,7 +35,7 @@ First, we indicate the parcel's initial thermodynamic conditions.
 
     P0 = 77500. # Pressure, Pa
     T0 = 274.   # Temperature, K
-    S0 = -0.02  # Supersaturation, 1-RH (98% here)
+    S0 = -0.02  # Supersaturation, RH-1 (with RH = 98% here)"
 
 Next, we define the aerosols present in the parcel. The model itself is
 agnostic to how the aerosol are specified; it simply expects lists of


### PR DESCRIPTION
This is a tiny change that will hopefully save others headache trying to understand... the example provided of a 98% RH initial parcel having a supersaturation of -0.02 is correct, but technically this is S = RH - 1, not 1-RH as currently documented.

I'm not sure if `docs/examples/basic_run.rst` is intended to be gitignored or not, I can remove that from the rst file if that's part of an automated build, etc.

Thanks!