### PR TITLE
feat(v2): default console output polish for ParcelModelJAX

### DIFF
--- a/examples/jax/live_run.py
+++ b/examples/jax/live_run.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Parcel run with master-style live integration loop output.
+
+Prints z / T / S after each integration chunk (``live=True``). Combine with
+``console=True`` for setup tables and the post-solve activation summary.
+
+Usage
+-----
+    python examples/jax/live_run.py
+    python examples/jax/live_run.py --chunk-dt 5 --no-console
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pyrcel as pm
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--chunk-dt",
+        type=float,
+        default=10.0,
+        help="simulation-time chunk length for live rows (s)",
+    )
+    p.add_argument(
+        "--no-console",
+        action="store_true",
+        help="live loop only (skip setup/summary tables)",
+    )
+    a = p.parse_args()
+
+    aerosol = pm.AerosolSpecies(
+        "NaCl",
+        {"r_drys": [0.1, 0.25, 0.5], "Nis": [500.0, 200.0, 50.0]},
+        kappa=1.2,
+    )
+    m = pm.ParcelModelJAX(
+        [aerosol],
+        V=1.0,
+        T0=283.15,
+        S0=-0.02,
+        P0=85000.0,
+        console=not a.no_console,
+    )
+    m.run(
+        100.0,
+        output_dt=1.0,
+        terminate=True,
+        terminate_depth=10.0,
+        live=True,
+        live_chunk_dt=a.chunk_dt,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyrcel/console_report.py
+++ b/pyrcel/console_report.py
@@ -2,7 +2,8 @@
 
 Default UX (``console=True``): single adaptive solve, compile/integrate phase banners,
 rich setup and integration-plan tables, a post-hoc trajectory sample, and the activation
-summary. Live mid-solve updates (``live=True``) are deferred to a follow-up PR.
+summary. ``live=True`` adds a master-style per-chunk z/T/S table during integration
+(interactive-only; kept out of the ``jit``/``grad`` path).
 
 Uses the ``logging`` module for one-line phase messages (``[pyrcel] ...``) and ``print``
 for aligned tables so interactive runs stay readable without extra dependencies.
@@ -201,6 +202,8 @@ def print_integration_plan(
     max_steps,
     rtol,
     progress,
+    live=False,
+    live_chunk_dt=10.0,
 ) -> None:
     print()
     print("  Integration plan")
@@ -209,13 +212,53 @@ def print_integration_plan(
         if terminate
         else "no (integrate to t_end)"
     )
-    prog = "TextProgressMeter" if progress else "none"
+    if live:
+        prog = f"live chunk loop ({live_chunk_dt:g} s chunks)"
+    elif progress:
+        prog = "TextProgressMeter"
+    else:
+        prog = "none"
     print(f"    t_end cap     {t_end:g} s")
     print(f"    output_dt     {output_dt:g} s")
     print(f"    terminate     {term}")
     print(f"    solver        Kvaerno5 + PIDController  rtol={rtol:.0e}  max_steps={max_steps}")
     print(f"    progress      {prog}")
     print(_hline())
+
+
+class LiveStepPrinter:
+    """Master-style integration loop table (``CVODEIntegrator.integrate``)."""
+
+    _HEADER = (
+        "\n  Integration loop\n\n"
+        "    step     time  walltime  Δwalltime |     z       T       S\n"
+        "   ------------------------------------|----------------------"
+    )
+    _ROW = "   {:5d} {:7.2f}s  {:7.2f}s  {:8.2f}s | {:5.1f} {:7.2f} {:6.2f}%"
+    _FOOTER = "   ---- end of integration loop ----"
+
+    def __init__(self) -> None:
+        self._started = False
+
+    def __call__(
+        self,
+        step: int,
+        t: float,
+        z: float,
+        T: float,
+        S_pct: float,
+        wall_total: float,
+        wall_delta: float,
+    ) -> None:
+        if not self._started:
+            print(self._HEADER)
+            self._started = True
+        print(self._ROW.format(step, t, wall_total, wall_delta, z, T, S_pct))
+
+    def finish(self) -> None:
+        if self._started:
+            print(self._FOOTER)
+            print()
 
 
 def print_termination_narrative(info: dict) -> None:

--- a/pyrcel/console_report.py
+++ b/pyrcel/console_report.py
@@ -1,0 +1,293 @@
+"""Formatted console output for the interactive ``ParcelModelJAX`` layer.
+
+Default UX (``console=True``): single adaptive solve, compile/integrate phase banners,
+rich setup and integration-plan tables, a post-hoc trajectory sample, and the activation
+summary. Live mid-solve updates (``live=True``) are deferred to a follow-up PR.
+
+Uses the ``logging`` module for one-line phase messages (``[pyrcel] ...``) and ``print``
+for aligned tables so interactive runs stay readable without extra dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable
+
+import numpy as np
+
+from . import constants as c
+from .distributions import Lognorm, MultiModeLognorm
+from .updraft import AbstractUpdraft, ConstantV
+
+log = logging.getLogger("pyrcel")
+
+#: Rows shown in the post-hoc trajectory table (subsampled if longer).
+MAX_TRAJECTORY_ROWS = 24
+#: Phase durations above this likely include one-time XLA compilation.
+COMPILE_HINT_SECONDS = 1.0
+
+
+class _PyrcelFormatter(logging.Formatter):
+    """Format log lines without ``%``-style interpolation on the message body."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return f"[pyrcel] {record.getMessage()}"
+
+
+def configure_logging() -> None:
+    """Attach a stdout handler for ``pyrcel`` if none is configured yet."""
+    if log.handlers:
+        return
+    handler = logging.StreamHandler()
+    handler.setFormatter(_PyrcelFormatter())
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+    log.propagate = False
+
+
+def backend_banner() -> str:
+    """One-line backend / device summary."""
+    try:
+        import jax
+
+        x64 = bool(jax.config.read("jax_enable_x64"))
+        device = jax.devices()[0]
+        return f"JAX {jax.__version__} | {device} | float64={'on' if x64 else 'off'}"
+    except Exception:
+        return "JAX backend (version unavailable)"
+
+
+class PhaseTimer:
+    """Track phase wall times and whether XLA compile was likely involved."""
+
+    def __init__(self) -> None:
+        self._seen: set[tuple] = set()
+
+    def run(self, key: tuple, label: str, fn: Callable, *args, **kwargs):
+        """Run ``fn``, log duration, and note likely first-time compilation."""
+        configure_logging()
+        first = key not in self._seen
+        if first:
+            log.info("Compiling %s...", label)
+        else:
+            log.info("%s...", label)
+        t0 = time.perf_counter()
+        result = fn(*args, **kwargs)
+        # Block JAX async dispatch so wall time reflects the real work.
+        _block_until_ready(result)
+        elapsed = time.perf_counter() - t0
+        self._seen.add(key)
+        if first and elapsed >= COMPILE_HINT_SECONDS:
+            log.info("  finished in %.2f s (includes one-time XLA compile)", elapsed)
+        else:
+            log.info("  finished in %.2f s", elapsed)
+        return result, elapsed
+
+
+def _block_until_ready(result) -> None:
+    try:
+        import jax
+
+        if hasattr(result, "block_until_ready"):
+            result.block_until_ready()
+        elif isinstance(result, tuple):
+            for item in result:
+                _block_until_ready(item)
+        elif isinstance(result, dict):
+            for item in result.values():
+                _block_until_ready(item)
+    except Exception:
+        pass
+
+
+def _hline(width: int = 72, char: str = "-") -> str:
+    return char * width
+
+
+def _v_desc(V) -> str:
+    if isinstance(V, ConstantV):
+        return f"{float(V.V):.4g} m/s"
+    if isinstance(V, AbstractUpdraft):
+        return "V(t) profile"
+    return f"{float(V):.4g} m/s"
+
+
+def _aerosol_rows(aerosols) -> list[tuple[str, float, float, int, str, str]]:
+    """Build table rows: species, κ, N [cm⁻³], bins, size spec, notes."""
+    rows = []
+    for aer in aerosols:
+        dist = aer.distribution
+        if isinstance(dist, Lognorm):
+            rows.append(
+                (
+                    aer.species,
+                    aer.kappa,
+                    float(aer.total_N),
+                    aer.nr,
+                    f"μ={dist.mu:g} μm",
+                    f"σ={dist.sigma:g}",
+                )
+            )
+        elif isinstance(dist, MultiModeLognorm):
+            rows.append(
+                (
+                    aer.species,
+                    aer.kappa,
+                    float(aer.total_N),
+                    aer.nr,
+                    f"{len(dist.mus)} modes",
+                    "",
+                )
+            )
+        elif isinstance(dist, dict):
+            rows.append(
+                (aer.species, aer.kappa, float(aer.total_N), aer.nr, "monodisperse", "")
+            )
+        else:
+            rows.append((aer.species, aer.kappa, float(aer.total_N), aer.nr, "custom", ""))
+    return rows
+
+
+def print_setup(
+    *,
+    V,
+    T0,
+    S0,
+    P0,
+    accom,
+    nr,
+    aerosols,
+    y0,
+    equil_elapsed: float,
+    equil_residual: float,
+) -> None:
+    """Parcel configuration, aerosol modes, and equilibrated initial state."""
+    configure_logging()
+    print()
+    print("Parcel model (JAX / diffrax)")
+    print(_hline())
+    print(f"  Backend   {backend_banner()}")
+    print()
+    print("  Configuration")
+    print(f"    {'V':<12} {_v_desc(V):<18} {'accom':<12} {accom:.4g}")
+    print(f"    {'T0':<12} {T0:.2f} K{'':<10} {'P0':<12} {P0 / 100.0:.1f} hPa")
+    print(f"    {'S0':<12} {S0:+.5f} ({100 * S0:+.2f} %){'':<3} {'bins':<12} {nr}")
+    print()
+    rows = _aerosol_rows(aerosols)
+    print(f"  {'species':<12} {'κ':>6} {'N [cm⁻³]':>12} {'bins':>6}  size")
+    print(f"  {_hline(68, '-')}")
+    for sp, kap, n, nb, spec, note in rows:
+        extra = f"  {note}" if note else ""
+        print(f"  {sp:<12} {kap:6.3f} {n:12.1f} {nb:6d}  {spec}{extra}")
+    print()
+    z, P, T, wv, wc, wi, S = y0[:7]
+    print("  Equilibrated initial state")
+    print(f"    equilibration   {equil_elapsed * 1e3:.1f} ms  |Seq-S0|_max = {equil_residual:.2e}")
+    print(
+        f"    {'P':>4} {P / 100.0:8.1f} hPa   {'T':>3} {T:7.2f} K   "
+        f"{'wv':>3} {wv * 1e3:8.3g} g/kg   {'wc':>3} {wc * 1e3:8.2e} g/kg   "
+        f"{'S':>3} {S:+.5f}"
+    )
+    print(_hline())
+
+
+def print_integration_plan(
+    *,
+    t_end,
+    output_dt,
+    terminate,
+    terminate_depth,
+    max_steps,
+    rtol,
+    progress,
+) -> None:
+    print()
+    print("  Integration plan")
+    term = (
+        f"yes (+{terminate_depth:g} m past S_max)"
+        if terminate
+        else "no (integrate to t_end)"
+    )
+    prog = "TextProgressMeter" if progress else "none"
+    print(f"    t_end cap     {t_end:g} s")
+    print(f"    output_dt     {output_dt:g} s")
+    print(f"    terminate     {term}")
+    print(f"    solver        Kvaerno5 + PIDController  rtol={rtol:.0e}  max_steps={max_steps}")
+    print(f"    progress      {prog}")
+    print(_hline())
+
+
+def print_termination_narrative(info: dict) -> None:
+    if not info.get("activated", True):
+        log.warning("No interior supersaturation maximum before t_end — ran to horizon.")
+        return
+    smax_pct = 100.0 * info["smax"]
+    z_smax = info.get("z_smax")
+    z_end = info.get("z_end")
+    parts = [
+        f"S_max = {smax_pct:.4f} % at t = {info['t_smax']:.2f} s",
+    ]
+    if z_smax is not None:
+        parts[0] += f" (z = {z_smax:.1f} m)"
+    parts.append(f"stopped at t = {info['t_cutoff']:.2f} s")
+    if z_end is not None:
+        parts[-1] += f" (z = {z_end:.1f} m)"
+    msg = f"Termination: {parts[0]}; {parts[1]}."
+    log.info(msg)
+
+
+def print_trajectory_table(time, x, *, max_rows: int = MAX_TRAJECTORY_ROWS) -> None:
+    """Post-hoc sample of z, T, S, wc along the saved trajectory."""
+    time = np.asarray(time)
+    x = np.asarray(x)
+    n = len(time)
+    if n == 0:
+        return
+    if n > max_rows:
+        idx = np.unique(np.linspace(0, n - 1, max_rows, dtype=int))
+    else:
+        idx = np.arange(n)
+    print()
+    print("  Trajectory (post-hoc sample)")
+    print(f"  {'t [s]':>8} {'z [m]':>8} {'T [K]':>8} {'S [%]':>9} {'wc [g/kg]':>11}")
+    print(f"  {_hline(48, '-')}")
+    for i in idx:
+        row = x[i]
+        print(
+            f"  {time[i]:8.2f} {row[0]:8.1f} {row[2]:8.2f} "
+            f"{100 * row[6]:9.4f} {row[4] * 1e3:11.3e}"
+        )
+    print(_hline())
+
+
+def print_summary(summary: dict) -> None:
+    s = summary
+    print()
+    print("  Simulation summary")
+    print(_hline())
+    print(
+        f"  S_max = {s['S_max'] * 100:.4f} %  at t = {s['t_smax']:.2f} s "
+        f"(T = {s['T_smax']:.2f} K, z = {s.get('z_smax', float('nan')):.1f} m)"
+    )
+    print(f"  {'species':>12} {'eq_act':>8} {'kn_act':>8} {'N_act':>10} {'N':>10}")
+    for p in s["per_species"]:
+        print(
+            f"  {p['species']:>12} {p['eq_act_frac']:8.3f} "
+            f"{p['kn_act_frac']:8.3f} {p['N_act']:10.1f} {p['N']:10.1f}"
+        )
+    print(f"  total activated fraction = {s['total_act_frac']:.3f}")
+    print(_hline())
+    print()
+
+
+def equilibration_residual(T0, S0, r_drys, kappas, r0s) -> float:
+    from .thermo_jax import Seq
+
+    r_drys = np.asarray(r_drys)
+    kappas = np.asarray(kappas)
+    r0s = np.asarray(r0s)
+    if r0s.size == 0:
+        return 0.0
+    seq = np.array([float(Seq(r, rd, T0, k)) for r, rd, k in zip(r0s, r_drys, kappas)])
+    return float(np.max(np.abs(seq - S0)))

--- a/pyrcel/integrator_diffrax.py
+++ b/pyrcel/integrator_diffrax.py
@@ -217,6 +217,36 @@ def find_smax(y0, args, t_end, *, rtol=STATE_RTOL, atol=None, max_steps=100_000)
     return t_smax, smax, y_smax, activated
 
 
+def terminate_cutoff_time(
+    y0,
+    args,
+    t_end,
+    *,
+    terminate_depth: float,
+    t_smax,
+    y_smax,
+    activated: bool,
+    rtol: float = STATE_RTOL,
+    atol=None,
+    max_steps: int = 100_000,
+) -> float:
+    """Integration stop time for ``terminate=True`` (altitude past ``S_max``)."""
+    if not activated:
+        return float(t_end)
+    t_smax_f = float(t_smax)
+    V = args[4]
+    if isinstance(V, ConstantV):
+        return min(t_smax_f + terminate_depth / float(V.V), float(t_end))
+    if not callable(V):
+        return min(t_smax_f + terminate_depth / float(V), float(t_end))
+    z_target = float(y_smax[0]) + terminate_depth
+    nr = int(jnp.asarray(y0).shape[0] - N_STATE_VARS)
+    if atol is None:
+        atol = atol_vector(nr)
+    sol_d = _solve_to_depth(y0, args, t_end, z_target, rtol, atol, max_steps)
+    return min(float(sol_d.ts[-1]), float(t_end))
+
+
 def integrate_parcel_terminated(
     y0,
     args,
@@ -255,8 +285,6 @@ def integrate_parcel_terminated(
     if atol is None:
         atol = atol_vector(nr)
 
-    V = args[4]
-
     def _find():
         return find_smax(y0, args, t_end, rtol=rtol, atol=atol, max_steps=max_steps)
 
@@ -269,14 +297,19 @@ def integrate_parcel_terminated(
     t_smax_f = float(t_smax)
     if not activated:
         t_cutoff = float(t_end)
-    elif isinstance(V, ConstantV):
-        t_cutoff = min(t_smax_f + terminate_depth / float(V.V), float(t_end))
-    elif not callable(V):
-        t_cutoff = min(t_smax_f + terminate_depth / float(V), float(t_end))
     else:
-        z_target = float(y_smax[0]) + terminate_depth
-        sol_d = _solve_to_depth(y0, args, t_end, z_target, rtol, atol, max_steps)
-        t_cutoff = min(float(sol_d.ts[-1]), float(t_end))
+        t_cutoff = terminate_cutoff_time(
+            y0,
+            args,
+            t_end,
+            terminate_depth=terminate_depth,
+            t_smax=t_smax,
+            y_smax=y_smax,
+            activated=True,
+            rtol=rtol,
+            atol=atol,
+            max_steps=max_steps,
+        )
 
     ts = np.append(np.arange(0.0, t_cutoff, output_dt), t_cutoff)
     ts = jnp.asarray(ts)
@@ -300,3 +333,105 @@ def integrate_parcel_terminated(
         "z_end": float(np.asarray(sol.ys)[-1, 0]),
     }
     return np.asarray(sol.ts), np.asarray(sol.ys), info
+
+
+def integrate_parcel_chunked(
+    y0,
+    args,
+    t_final,
+    output_dt,
+    *,
+    chunk_dt=10.0,
+    rtol: float = STATE_RTOL,
+    atol=None,
+    max_steps: int = 100_000,
+    on_step=None,
+):
+    """Interactive-only integration in ``chunk_dt`` slices with optional per-chunk callback.
+
+    Unlike :func:`integrate_parcel`, this runs a Python loop over successive
+    ``diffeqsolve`` calls so host code can print live diagnostics between chunks. It is
+    **not** ``jit``/``vmap``/``grad``-safe and must not be used on the differentiable
+    path. Adaptive solver state is re-initialised at each chunk boundary (acceptable for
+    CLI feedback; see design doc §4.7).
+
+    Parameters
+    ----------
+    on_step : callable, optional
+        ``on_step(step, t, z, T, S_pct, wall_total, wall_delta)`` invoked immediately
+        before each chunk integrate (master ``CVODEIntegrator`` semantics).
+
+    Returns
+    -------
+    ts, ys, success
+        Concatenated output grid and whether every chunk reported success.
+    """
+    import time
+
+    y0 = jnp.asarray(y0)
+    t_final = float(t_final)
+    output_dt = float(output_dt)
+    chunk_dt = float(chunk_dt)
+    nr = int(y0.shape[0] - N_STATE_VARS)
+    if atol is None:
+        atol = atol_vector(nr)
+
+    y_curr = y0
+    t_curr = 0.0
+    ts_parts: list[np.ndarray] = []
+    ys_parts: list[np.ndarray] = []
+    step = 0
+    wall_total = 0.0
+    wall_prev = time.perf_counter()
+    success = True
+
+    while t_curr < t_final - 1e-12:
+        step += 1
+        t_next = min(t_curr + chunk_dt, t_final)
+        n_out = max(1, int(round((t_next - t_curr) / output_dt)))
+        chunk_ts = np.linspace(t_curr, t_next, n_out + 1)
+
+        if on_step is not None:
+            state = np.asarray(y_curr)
+            now = time.perf_counter()
+            wall_delta = now - wall_prev
+            wall_total += wall_delta
+            on_step(
+                step,
+                t_curr,
+                float(state[0]),
+                float(state[2]),
+                float(state[6]) * 100.0,
+                wall_total,
+                wall_delta,
+            )
+            wall_prev = now
+
+        sol = integrate_parcel(
+            y_curr,
+            args,
+            jnp.asarray(chunk_ts),
+            rtol=rtol,
+            atol=atol,
+            max_steps=max_steps,
+        )
+        jax.block_until_ready(sol.ys)
+        if not bool(sol.result == dfx.RESULTS.successful):
+            success = False
+            break
+
+        ts = np.asarray(sol.ts)
+        ys = np.asarray(sol.ys)
+        if ts_parts:
+            ts_parts.append(ts[1:])
+            ys_parts.append(ys[1:])
+        else:
+            ts_parts.append(ts)
+            ys_parts.append(ys)
+
+        y_curr = sol.ys[-1]
+        t_curr = float(ts[-1])
+
+    if not ts_parts:
+        return np.array([0.0]), np.asarray(y0)[None, :], False
+    return np.concatenate(ts_parts), np.concatenate(ys_parts, axis=0), success

--- a/pyrcel/integrator_diffrax.py
+++ b/pyrcel/integrator_diffrax.py
@@ -228,6 +228,7 @@ def integrate_parcel_terminated(
     atol=None,
     max_steps: int = 100_000,
     progress_meter=None,
+    phase_timer=None,
 ):
     """Integrate, stopping ``terminate_depth`` metres past the supersaturation max.
 
@@ -256,9 +257,15 @@ def integrate_parcel_terminated(
 
     V = args[4]
 
-    t_smax, smax, y_smax, activated = find_smax(
-        y0, args, t_end, rtol=rtol, atol=atol, max_steps=max_steps
-    )
+    def _find():
+        return find_smax(y0, args, t_end, rtol=rtol, atol=atol, max_steps=max_steps)
+
+    if phase_timer is not None:
+        (t_smax, smax, y_smax, activated), _ = phase_timer.run(
+            ("smax", nr), "S_max event solve", _find
+        )
+    else:
+        t_smax, smax, y_smax, activated = _find()
     t_smax_f = float(t_smax)
     if not activated:
         t_cutoff = float(t_end)
@@ -275,12 +282,21 @@ def integrate_parcel_terminated(
     ts = jnp.asarray(ts)
     if progress_meter is None:
         progress_meter = dfx.NoProgressMeter()
-    sol = _solve(y0, args, ts, rtol, atol, None, max_steps, progress_meter)
+
+    def _traj():
+        return _solve(y0, args, ts, rtol, atol, None, max_steps, progress_meter)
+
+    if phase_timer is not None:
+        sol, _ = phase_timer.run(("traj", nr, len(ts)), "trajectory solve", _traj)
+    else:
+        sol = _traj()
     info = {
         "t_smax": t_smax_f,
         "smax": float(smax),
         "t_cutoff": t_cutoff,
         "activated": activated,
         "success": bool(sol.result == dfx.RESULTS.successful),
+        "z_smax": float(y_smax[0]),
+        "z_end": float(np.asarray(sol.ys)[-1, 0]),
     }
     return np.asarray(sol.ts), np.asarray(sol.ys), info

--- a/pyrcel/model_jax.py
+++ b/pyrcel/model_jax.py
@@ -25,6 +25,7 @@ import numpy as np
 from . import constants as c
 from .activation import binned_activation
 from .console_report import (
+    LiveStepPrinter,
     PhaseTimer,
     equilibration_residual,
     print_integration_plan,
@@ -36,8 +37,11 @@ from .console_report import (
 from .equilibrate_jax import equilibrate_initial_state
 from .integrator_diffrax import (
     STATE_RTOL,
+    find_smax,
     integrate_parcel,
+    integrate_parcel_chunked,
     integrate_parcel_terminated,
+    terminate_cutoff_time,
 )
 from .updraft import AbstractUpdraft, ConstantV
 
@@ -137,6 +141,8 @@ class ParcelModelJAX:
         terminate_depth=10.0,
         max_steps=100_000,
         progress=False,
+        live=False,
+        live_chunk_dt=10.0,
         trajectory_table=None,
         output_fmt="dataframes",
     ):
@@ -157,7 +163,14 @@ class ParcelModelJAX:
             Adaptive-step cap for the solver.
         progress : bool
             Show a live text progress meter during the solve (``False`` by default).
-            Mutually exclusive with ``live`` (reserved for a future chunk-loop mode).
+            Mutually exclusive with ``live``.
+        live : bool
+            Print a master-style z/T/S table after each integration chunk (``False`` by
+            default). Uses an interactive-only Python chunk loop; mutually exclusive
+            with ``progress``.
+        live_chunk_dt : float
+            Simulation-time length of each live-integration chunk (s). Default ``10``,
+            matching ``master``'s typical ``solver_dt``.
         trajectory_table : bool or None
             Print a post-hoc trajectory sample after integration. ``None`` (default)
             follows ``console`` (on when ``console=True``).
@@ -172,13 +185,17 @@ class ParcelModelJAX:
         """
         if output_fmt not in ("dataframes", "arrays", "smax"):
             raise ValueError(f"invalid output_fmt {output_fmt!r}")
+        if live and progress:
+            raise ValueError("live and progress are mutually exclusive")
 
         import diffrax as dfx
 
         if trajectory_table is None:
-            trajectory_table = self.console
+            trajectory_table = self.console and not live
 
-        meter = dfx.TextProgressMeter() if progress else dfx.NoProgressMeter()
+        meter = dfx.NoProgressMeter() if live else (
+            dfx.TextProgressMeter() if progress else dfx.NoProgressMeter()
+        )
 
         if self.console:
             print_integration_plan(
@@ -189,12 +206,71 @@ class ParcelModelJAX:
                 max_steps=max_steps,
                 rtol=STATE_RTOL,
                 progress=progress,
+                live=live,
+                live_chunk_dt=live_chunk_dt,
             )
 
         peak = None
         run_info = None
-        timer = self._phase_timer if self.console else None
-        if terminate:
+        timer = self._phase_timer if self.console and not live else None
+        live_printer = LiveStepPrinter() if live else None
+
+        if live:
+            t_final = float(t_end)
+            activated = True
+            t_smax_f = float("nan")
+            smax = float("nan")
+            y_smax = None
+
+            if terminate:
+                def _find():
+                    return find_smax(
+                        self.y0, self.args, t_end,
+                        max_steps=max_steps,
+                    )
+
+                if timer is not None:
+                    (t_smax, smax, y_smax, activated), _ = timer.run(
+                        ("smax", self._nr), "S_max event solve", _find
+                    )
+                else:
+                    t_smax, smax, y_smax, activated = _find()
+                t_smax_f = float(t_smax)
+                if activated:
+                    peak = (float(smax), t_smax_f)
+                    t_final = terminate_cutoff_time(
+                        self.y0,
+                        self.args,
+                        t_end,
+                        terminate_depth=terminate_depth,
+                        t_smax=t_smax,
+                        y_smax=y_smax,
+                        activated=True,
+                        max_steps=max_steps,
+                    )
+
+            ts, ys, success = integrate_parcel_chunked(
+                self.y0,
+                self.args,
+                t_final,
+                output_dt,
+                chunk_dt=live_chunk_dt,
+                max_steps=max_steps,
+                on_step=live_printer,
+            )
+            if live_printer is not None:
+                live_printer.finish()
+            ts, ys = np.asarray(ts), np.asarray(ys)
+            run_info = {
+                "success": success,
+                "activated": activated,
+                "t_smax": t_smax_f,
+                "smax": smax,
+                "t_cutoff": float(ts[-1]) if len(ts) else t_final,
+                "z_smax": float(y_smax[0]) if y_smax is not None else float("nan"),
+                "z_end": float(ys[-1, c.STATE_VAR_MAP["z"]]) if len(ys) else float("nan"),
+            }
+        elif terminate:
             ts, ys, run_info = integrate_parcel_terminated(
                 self.y0, self.args, t_end, output_dt,
                 terminate_depth=terminate_depth, max_steps=max_steps,

--- a/pyrcel/model_jax.py
+++ b/pyrcel/model_jax.py
@@ -24,8 +24,18 @@ import numpy as np
 
 from . import constants as c
 from .activation import binned_activation
+from .console_report import (
+    PhaseTimer,
+    equilibration_residual,
+    print_integration_plan,
+    print_setup,
+    print_summary,
+    print_termination_narrative,
+    print_trajectory_table,
+)
 from .equilibrate_jax import equilibrate_initial_state
 from .integrator_diffrax import (
+    STATE_RTOL,
     integrate_parcel,
     integrate_parcel_terminated,
 )
@@ -78,19 +88,39 @@ class ParcelModelJAX:
         self._Nis = np.asarray(Nis)
         self._nr = len(r_drys)
 
+        import time
+
+        t0 = time.perf_counter()
         y0 = equilibrate_initial_state(
             self.T0, self.S0, self.P0, self._r_drys, self._kappas, self._Nis
         )
+        self._equil_elapsed = time.perf_counter() - t0
         self.y0 = np.asarray(y0)
+        self._equil_residual = equilibration_residual(
+            self.T0, self.S0, self._r_drys, self._kappas, self.y0[c.N_STATE_VARS:]
+        )
 
         # Outputs, populated by run().
         self.x = None
         self.time = None
         self.heights = None
         self._summary = None
+        self._phase_timer = PhaseTimer()
+        self._run_info: dict | None = None
 
         if self.console:
-            self._print_setup()
+            print_setup(
+                V=self.V,
+                T0=self.T0,
+                S0=self.S0,
+                P0=self.P0,
+                accom=self.accom,
+                nr=self._nr,
+                aerosols=self.aerosols,
+                y0=self.y0,
+                equil_elapsed=self._equil_elapsed,
+                equil_residual=self._equil_residual,
+            )
 
     @property
     def args(self) -> tuple:
@@ -107,6 +137,7 @@ class ParcelModelJAX:
         terminate_depth=10.0,
         max_steps=100_000,
         progress=False,
+        trajectory_table=None,
         output_fmt="dataframes",
     ):
         """Run the simulation.
@@ -125,7 +156,11 @@ class ParcelModelJAX:
         max_steps : int
             Adaptive-step cap for the solver.
         progress : bool
-            Show a live text progress meter during the solve.
+            Show a live text progress meter during the solve (``False`` by default).
+            Mutually exclusive with ``live`` (reserved for a future chunk-loop mode).
+        trajectory_table : bool or None
+            Print a post-hoc trajectory sample after integration. ``None`` (default)
+            follows ``console`` (on when ``console=True``).
         output_fmt : {'dataframes', 'arrays', 'smax'}
             * ``'dataframes'`` -- ``(parcel_df, {species: aerosol_df})`` (pandas),
             * ``'arrays'`` -- ``(state_array, heights)``,
@@ -140,27 +175,53 @@ class ParcelModelJAX:
 
         import diffrax as dfx
 
-        meter = dfx.TextProgressMeter() if progress else None
+        if trajectory_table is None:
+            trajectory_table = self.console
+
+        meter = dfx.TextProgressMeter() if progress else dfx.NoProgressMeter()
+
+        if self.console:
+            print_integration_plan(
+                t_end=t_end,
+                output_dt=output_dt,
+                terminate=terminate,
+                terminate_depth=terminate_depth,
+                max_steps=max_steps,
+                rtol=STATE_RTOL,
+                progress=progress,
+            )
 
         peak = None
+        run_info = None
+        timer = self._phase_timer if self.console else None
         if terminate:
-            ts, ys, info = integrate_parcel_terminated(
+            ts, ys, run_info = integrate_parcel_terminated(
                 self.y0, self.args, t_end, output_dt,
                 terminate_depth=terminate_depth, max_steps=max_steps,
                 progress_meter=meter,
+                phase_timer=timer,
             )
-            success = info["success"]
-            if info["activated"]:
-                # Event-localized peak (precise), not the output-grid argmax.
-                peak = (info["smax"], info["t_smax"])
+            ts, ys = np.asarray(ts), np.asarray(ys)
+            success = run_info["success"]
+            if run_info["activated"]:
+                peak = (run_info["smax"], run_info["t_smax"])
         else:
-            ts = np.append(np.arange(0.0, float(t_end), output_dt), float(t_end))
-            sol = integrate_parcel(
-                self.y0, self.args, ts, max_steps=max_steps, progress_meter=meter
-            )
+            ts_arr = np.append(np.arange(0.0, float(t_end), output_dt), float(t_end))
+
+            def _integrate():
+                return integrate_parcel(
+                    self.y0, self.args, ts_arr, max_steps=max_steps, progress_meter=meter
+                )
+
+            key = ("fixed", self._nr, len(ts_arr))
+            if timer is not None:
+                sol, _ = timer.run(key, "integration (fixed horizon)", _integrate)
+            else:
+                sol = _integrate()
             ys = np.asarray(sol.ys)
             ts = np.asarray(sol.ts)
             success = bool(sol.result == dfx.RESULTS.successful)
+            run_info = {"success": success, "activated": True, "t_cutoff": float(ts[-1])}
 
         if not success:
             from .util import ParcelModelError
@@ -170,10 +231,15 @@ class ParcelModelJAX:
         self.x = np.asarray(ys)
         self.time = np.asarray(ts)
         self.heights = self.x[:, c.STATE_VAR_MAP["z"]]
+        self._run_info = run_info
         self._summary = self._compute_summary(peak)
 
         if self.console:
-            self._print_summary()
+            if run_info is not None:
+                print_termination_narrative(run_info)
+            if trajectory_table:
+                print_trajectory_table(self.time, self.x)
+            print_summary(self._summary)
 
         if output_fmt == "smax":
             return float(self._summary["S_max"])
@@ -217,6 +283,7 @@ class ParcelModelJAX:
             "S_max": S_max,
             "t_smax": t_smax,
             "T_smax": T_smax,
+            "z_smax": float(self.x[si, c.STATE_VAR_MAP["z"]]),
             "per_species": per_species,
             "total_act_frac": (total_act / total_N) if total_N > 0 else float("nan"),
         }
@@ -336,34 +403,9 @@ class ParcelModelJAX:
         """Write the run to a NetCDF file (see :meth:`to_dataset`)."""
         self.to_dataset().to_netcdf(filename)
         if self.console:
-            print(f"Saved output to {filename}")
+            from .console_report import configure_logging
+
+            configure_logging()
+            log = __import__("logging").getLogger("pyrcel")
+            log.info("Saved output to %s", filename)
         return filename
-
-    # --- console output -----------------------------------------------------------
-
-    def _print_setup(self):
-        print("Parcel model (JAX/diffrax) -- initial conditions")
-        print("-" * 52)
-        V_desc = "V(t)" if isinstance(self.V, AbstractUpdraft) and not isinstance(
-            self.V, ConstantV
-        ) else f"{float(self.V.V) if isinstance(self.V, ConstantV) else self.V:.3g} m/s"
-        print(f"  V = {V_desc}   T0 = {self.T0:.2f} K   "
-              f"P0 = {self.P0 / 100.0:.1f} hPa   S0 = {self.S0:+.4f}")
-        print(f"  aerosol bins: {self._nr}   accom = {self.accom:.3g}")
-        z, P, T, wv, wc, wi, S = self.y0[:7]
-        print(f"  y0: P={P / 100:.1f} hPa  T={T:.2f} K  "
-              f"wv={wv * 1e3:.3g} g/kg  wc={wc * 1e3:.2e} g/kg  S={S:+.4f}")
-        print("-" * 52)
-
-    def _print_summary(self):
-        s = self._summary
-        print("\nSimulation summary")
-        print("-" * 52)
-        print(f"  S_max = {s['S_max'] * 100:.4f} %  at t = {s['t_smax']:.2f} s "
-              f"(T = {s['T_smax']:.2f} K)")
-        print(f"  {'species':>12} {'eq_act':>8} {'kn_act':>8} {'N_act':>10} {'N':>10}")
-        for p in s["per_species"]:
-            print(f"  {p['species']:>12} {p['eq_act_frac']:8.3f} "
-                  f"{p['kn_act_frac']:8.3f} {p['N_act']:10.1f} {p['N']:10.1f}")
-        print(f"  total activated fraction = {s['total_act_frac']:.3f}")
-        print("-" * 52)

--- a/tests/test_console_report.py
+++ b/tests/test_console_report.py
@@ -46,6 +46,18 @@ def test_print_trajectory_table_subsamples(capsys):
     assert out.count("\n") >= 10
 
 
+def test_live_step_printer(capsys):
+    from pyrcel.console_report import LiveStepPrinter
+
+    printer = LiveStepPrinter()
+    printer(1, 0.0, 0.0, 283.15, -2.0, 0.0, 0.0)
+    printer.finish()
+    out = capsys.readouterr().out
+    assert "Integration loop" in out
+    assert "283.15" in out
+    assert "end of integration loop" in out
+
+
 def test_print_summary(capsys):
     print_summary(
         {

--- a/tests/test_console_report.py
+++ b/tests/test_console_report.py
@@ -1,0 +1,71 @@
+"""Unit tests for :mod:`pyrcel.console_report`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pyrcel.console_report import (
+    PhaseTimer,
+    equilibration_residual,
+    print_summary,
+    print_trajectory_table,
+)
+
+
+def test_equilibration_residual_zero_when_empty():
+    assert equilibration_residual(280.0, 0.01, [], [], np.array([])) == 0.0
+
+
+def test_phase_timer_logs_first_compile(capsys):
+    calls = []
+
+    def fn():
+        calls.append(1)
+        return np.array([1.0])
+
+    timer = PhaseTimer()
+    timer.run(("k",), "test phase", fn)
+    timer.run(("k",), "test phase", fn)
+    err = capsys.readouterr().err
+    assert "Compiling test phase" in err
+    assert err.count("finished in") == 2
+    assert len(calls) == 2
+
+
+def test_print_trajectory_table_subsamples(capsys):
+    n = 100
+    time = np.linspace(0, 10, n)
+    x = np.zeros((n, 7))
+    x[:, 0] = np.linspace(0, 1000, n)
+    x[:, 2] = 280.0
+    x[:, 4] = 1e-6
+    x[:, 6] = 0.01
+    print_trajectory_table(time, x, max_rows=10)
+    out = capsys.readouterr().out
+    assert "Trajectory (post-hoc sample)" in out
+    assert out.count("\n") >= 10
+
+
+def test_print_summary(capsys):
+    print_summary(
+        {
+            "S_max": 0.012,
+            "t_smax": 42.0,
+            "T_smax": 265.0,
+            "z_smax": 1200.0,
+            "per_species": [
+                {
+                    "species": "AS",
+                    "eq_act_frac": 0.5,
+                    "kn_act_frac": 0.4,
+                    "N": 100.0,
+                    "N_act": 50.0,
+                }
+            ],
+            "total_act_frac": 0.5,
+        }
+    )
+    out = capsys.readouterr().out
+    assert "Simulation summary" in out
+    assert "AS" in out
+    assert "total activated fraction" in out

--- a/tests/test_model_jax.py
+++ b/tests/test_model_jax.py
@@ -106,6 +106,39 @@ def test_time_varying_updraft_runs():
     assert np.isfinite(smax) and smax > 0
 
 
+def test_live_and_progress_mutually_exclusive():
+    sc = scn.get_scenario("mono")
+    ic, run = sc["initial"], sc["run"]
+    m = ParcelModelJAX(
+        scn.build_aerosols(sc),
+        V=ic["V"], T0=ic["T0"], S0=ic["S0"], P0=ic["P0"], accom=ic["accom"],
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        m.run(
+            run["t_end"], run["output_dt"],
+            live=True, progress=True,
+        )
+
+
+def test_live_output(capsys):
+    sc = scn.get_scenario("mono")
+    ic, run = sc["initial"], sc["run"]
+    m = ParcelModelJAX(
+        scn.build_aerosols(sc),
+        V=ic["V"], T0=ic["T0"], S0=ic["S0"], P0=ic["P0"], accom=ic["accom"],
+        console=False,
+    )
+    m.run(
+        run["t_end"], run["output_dt"],
+        terminate=True, terminate_depth=run["terminate_depth"],
+        live=True, live_chunk_dt=20.0,
+    )
+    out = capsys.readouterr().out
+    assert "Integration loop" in out
+    assert "end of integration loop" in out
+    assert "|" in out  # z/T/S column divider
+
+
 def test_console_output(capsys, caplog):
     import logging
 

--- a/tests/test_model_jax.py
+++ b/tests/test_model_jax.py
@@ -106,7 +106,10 @@ def test_time_varying_updraft_runs():
     assert np.isfinite(smax) and smax > 0
 
 
-def test_console_output(capsys):
+def test_console_output(capsys, caplog):
+    import logging
+
+    caplog.set_level(logging.INFO, logger="pyrcel")
     sc = scn.get_scenario("mono")
     ic, run = sc["initial"], sc["run"]
     m = ParcelModelJAX(
@@ -116,6 +119,12 @@ def test_console_output(capsys):
     )
     m.run(run["t_end"], run["output_dt"], terminate=True, terminate_depth=run["terminate_depth"])
     out = capsys.readouterr().out
-    assert "initial conditions" in out.lower()
+    assert "Configuration" in out
+    assert "Equilibrated initial state" in out
+    assert "Integration plan" in out
+    assert "Trajectory (post-hoc sample)" in out
+    assert "Simulation summary" in out
     assert "S_max" in out
     assert "total activated fraction" in out
+    assert "Compiling S_max event solve" in caplog.text
+    assert "Termination:" in caplog.text


### PR DESCRIPTION
## Summary

- Add `pyrcel/console_report.py` with setup tables, integration plan, post-hoc trajectory sample, activation summary, and `[pyrcel]` phase timing logs (compile vs integrate).
- Wire `ParcelModelJAX(console=True)` through the new reporter; split terminated runs into separate S_max and trajectory phases for clearer compile banners.
- Extend `integrate_parcel_terminated` info with `z_smax` / `z_end` for termination narrative.

Live mid-solve row updates (`live=True`) are intentionally deferred to a follow-up PR.

## Test plan

- [x] `pytest tests/test_console_report.py`
- [x] `pytest tests/test_model_jax.py::test_console_output`
- [x] Full suite (`219` tests passing)


Made with [Cursor](https://cursor.com)