### PR TITLE
refactor(v2): rename ParcelModelJAX → ParcelModel; output_fmt → mode

### DIFF
--- a/pyrcel/console_report.py
+++ b/pyrcel/console_report.py
@@ -1,4 +1,4 @@
-"""Formatted console output for the interactive ``ParcelModelJAX`` layer.
+"""Formatted console output for the interactive :class:`~pyrcel.model.ParcelModel` layer.
 
 Default UX (``console=True``): single adaptive solve, compile/integrate phase banners,
 rich setup and integration-plan tables, a post-hoc trajectory sample, and the activation
@@ -353,7 +353,7 @@ def print_summary(summary: dict) -> None:
     ----------
     summary : dict
         Summary dict as returned by
-        :meth:`~pyrcel.model.ParcelModelJAX._compute_summary`; expected keys
+        :meth:`~pyrcel.model.ParcelModel._compute_summary`; expected keys
         ``S_max``, ``t_smax``, ``T_smax``, ``z_smax``, ``per_species``, and
         ``total_act_frac``.
     """

--- a/pyrcel/integrator.py
+++ b/pyrcel/integrator.py
@@ -5,7 +5,7 @@ A single adaptive ``diffeqsolve`` with a stiff ESDIRK solver (``Kvaerno5``) and 
 cadence comes from ``SaveAt(ts=...)`` via dense interpolation -- no manual
 ``solver_dt`` chunking.
 
-Tolerances mirror the CVode setup in ``pyrcel/integrator.py``
+Tolerances mirror the CVode setup in ``pyrcel/legacy/integrator.py``
 (``rtol=1e-7`` and a per-component ``atol`` vector). ``Kvaerno5`` is A-/L-stable and
 stiffly accurate, the diffrax analog of CVode's BDF; its default ``VeryChord`` Newton
 root finder inherits these tolerances automatically.

--- a/pyrcel/model.py
+++ b/pyrcel/model.py
@@ -1,8 +1,8 @@
 """High-level v2 parcel-model interface (design doc §4.7 mode 2, Phase 6).
 
 A thin, user-facing wrapper over the differentiable JAX/diffrax core that mirrors the
-spirit of the master :class:`pyrcel.parcel.ParcelModel` without numba or Assimulo. It
-ties together the three v2 pieces:
+spirit of the legacy :class:`pyrcel.legacy.parcel.ParcelModel` without numba or
+Assimulo. It ties together the three v2 pieces:
 
 * equilibration of the initial wet radii (:mod:`pyrcel.equilibrate`),
 * a single adaptive ``diffrax`` solve, with optional event-based ``S_max`` termination
@@ -14,7 +14,7 @@ There are deliberately *two* presentation modes over the same numerical core (de
 core, while this class is the **interactive** layer -- an optional live progress meter and
 a post-solve summary table -- and is intentionally kept out of the differentiable path.
 
-``ParcelModel`` itself is a plain mutable Python class (per the locked decision); only the
+:class:`ParcelModel` is a plain mutable Python class (per the locked decision); only the
 inner vector field / updraft are Equinox modules.
 """
 
@@ -45,10 +45,10 @@ from .integrator import (
 )
 from .updraft import AbstractUpdraft, ConstantV
 
-__all__ = ["ParcelModelJAX"]
+__all__ = ["ParcelModel"]
 
 
-class ParcelModelJAX:
+class ParcelModel:
     """Set up and run a parcel-model simulation on the JAX/diffrax backend.
 
     Parameters
@@ -67,8 +67,8 @@ class ParcelModelJAX:
 
     Notes
     -----
-    Equilibration runs at construction (like ``master``'s ``_setup_run``), so ``y0`` is
-    available immediately as :pyattr:`y0`.
+    Equilibration runs at construction (like the legacy ``_setup_run``), so ``y0`` is
+    available immediately as :attr:`y0`.
     """
 
     def __init__(self, aerosols, V, T0, S0, P0, accom=c.ac, console=False):
@@ -144,7 +144,7 @@ class ParcelModelJAX:
         live=False,
         live_chunk_dt=10.0,
         trajectory_table=None,
-        output_fmt="dataframes",
+        mode="full",
     ):
         """Run the simulation.
 
@@ -156,7 +156,7 @@ class ParcelModelJAX:
         output_dt : float
             Output cadence (s); the trajectory is dense-interpolated to this grid.
         terminate : bool
-            Stop shortly after ``S_max`` (event-based; reproduces ``master``'s behaviour).
+            Stop shortly after ``S_max`` (event-based; reproduces legacy behaviour).
         terminate_depth : float
             Extra depth (m) to integrate past ``S_max`` before stopping.
         max_steps : int
@@ -165,26 +165,28 @@ class ParcelModelJAX:
             Show a live text progress meter during the solve (``False`` by default).
             Mutually exclusive with ``live``.
         live : bool
-            Print a master-style z/T/S table after each integration chunk (``False`` by
+            Print a legacy-style z/T/S table after each integration chunk (``False`` by
             default). Uses an interactive-only Python chunk loop; mutually exclusive
             with ``progress``.
         live_chunk_dt : float
-            Simulation-time length of each live-integration chunk (s). Default ``10``,
-            matching ``master``'s typical ``solver_dt``.
+            Simulation-time length of each live-integration chunk (s). Default ``10``.
         trajectory_table : bool or None
             Print a post-hoc trajectory sample after integration. ``None`` (default)
             follows ``console`` (on when ``console=True``).
-        output_fmt : {'dataframes', 'arrays', 'smax'}
-            * ``'dataframes'`` -- ``(parcel_df, {species: aerosol_df})`` (pandas),
+        mode : {'full', 'arrays', 'smax'}
+            * ``'full'`` -- ``(parcel_df, {species: aerosol_df})`` (pandas DataFrames),
             * ``'arrays'`` -- ``(state_array, heights)``,
-            * ``'smax'`` -- the scalar peak supersaturation.
+            * ``'smax'`` -- the scalar peak supersaturation (primary differentiable path).
+
+            ``'nd'`` (activated droplet number via kinetic-limitation diagnosis) is
+            deferred to a future release.
 
         Returns
         -------
-        Depends on ``output_fmt``; see above.
+        Depends on ``mode``; see above.
         """
-        if output_fmt not in ("dataframes", "arrays", "smax"):
-            raise ValueError(f"invalid output_fmt {output_fmt!r}")
+        if mode not in ("full", "arrays", "smax"):
+            raise ValueError(f"invalid mode {mode!r}")
         if live and progress:
             raise ValueError("live and progress are mutually exclusive")
 
@@ -326,9 +328,9 @@ class ParcelModelJAX:
                 print_trajectory_table(self.time, self.x)
             print_summary(self._summary)
 
-        if output_fmt == "smax":
+        if mode == "smax":
             return float(self._summary["S_max"])
-        if output_fmt == "arrays":
+        if mode == "arrays":
             return self.x, self.heights
         return self._to_dataframes()
 
@@ -524,3 +526,7 @@ class ParcelModelJAX:
             log = __import__("logging").getLogger("pyrcel")
             log.info("Saved output to %s", filename)
         return filename
+
+
+# Backward-compatible alias — prefer ParcelModel.
+ParcelModelJAX = ParcelModel

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,7 @@
 """End-to-end high-level model tests (design §7.3 full pipeline; Phase 6).
 
-Unlike ``test_trajectory`` (which seeds the v2 integrator with master's frozen ``y0``),
-these run the *whole* v2 pipeline -- :class:`pyrcel.model.ParcelModelJAX` does its own
+Unlike ``test_trajectory`` (which seeds the v2 integrator with a frozen ``y0``),
+these run the *whole* v2 pipeline -- :class:`pyrcel.model.ParcelModel` does its own
 ``optimistix`` equilibration, the diffrax solve with event termination, and the activation
 diagnostics -- and check the headline numbers against the CVode oracle:
 
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 import scenarios as scn
 
-from pyrcel.model import ParcelModelJAX
+from pyrcel.model import ParcelModel
 from pyrcel.updraft import InterpolatedUpdraft
 
 pytestmark = pytest.mark.slow
@@ -26,15 +26,15 @@ pytestmark = pytest.mark.slow
 S_MAX_RTOL = 1e-3
 ACT_FRAC_ATOL = 1e-3
 
-_MODEL_CACHE: dict[str, ParcelModelJAX] = {}
+_MODEL_CACHE: dict[str, ParcelModel] = {}
 
 
-def _model(scenario_name: str) -> ParcelModelJAX:
+def _model(scenario_name: str) -> ParcelModel:
     if scenario_name not in _MODEL_CACHE:
         sc = scn.get_scenario(scenario_name)
         ic = sc["initial"]
         run = sc["run"]
-        m = ParcelModelJAX(
+        m = ParcelModel(
             scn.build_aerosols(sc),
             V=ic["V"],
             T0=ic["T0"],
@@ -71,7 +71,7 @@ def test_activated_fraction_matches_oracle(oracle, scenario_name):
 def test_output_formats():
     sc = scn.get_scenario("simple_sulfate")
     ic, run = sc["initial"], sc["run"]
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=ic["V"],
         T0=ic["T0"],
@@ -79,20 +79,20 @@ def test_output_formats():
         P0=ic["P0"],
         accom=ic["accom"],
     )
-    parcel, aerosol = m.run(run["t_end"], run["output_dt"], output_fmt="dataframes")
+    parcel, aerosol = m.run(run["t_end"], run["output_dt"], mode="full")
     assert list(parcel.columns) == ["z", "P", "T", "wv", "wc", "wi", "S"]
     assert set(aerosol) == {"sulfate"}
     assert aerosol["sulfate"].shape[1] == m._nr
 
-    x, heights = m.run(run["t_end"], run["output_dt"], output_fmt="arrays")
+    x, heights = m.run(run["t_end"], run["output_dt"], mode="arrays")
     assert x.shape[0] == heights.shape[0]
     assert x.shape[1] == 7 + m._nr
 
-    smax = m.run(run["t_end"], run["output_dt"], output_fmt="smax")
+    smax = m.run(run["t_end"], run["output_dt"], mode="smax")
     assert isinstance(smax, float) and smax > 0
 
     with pytest.raises(ValueError):
-        m.run(run["t_end"], output_fmt="nonsense")
+        m.run(run["t_end"], mode="nonsense")
 
 
 def test_summary_structure():
@@ -107,7 +107,7 @@ def test_time_varying_updraft_runs():
     sc = scn.get_scenario("simple_sulfate")
     ic = sc["initial"]
     Vt = InterpolatedUpdraft(ts=[0.0, 40.0, 200.0], vs=[0.4, 1.2, 1.2])
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=Vt,
         T0=ic["T0"],
@@ -115,14 +115,14 @@ def test_time_varying_updraft_runs():
         P0=ic["P0"],
         accom=ic["accom"],
     )
-    smax = m.run(150.0, 1.0, terminate=True, terminate_depth=10.0, output_fmt="smax")
+    smax = m.run(150.0, 1.0, terminate=True, terminate_depth=10.0, mode="smax")
     assert np.isfinite(smax) and smax > 0
 
 
 def test_live_and_progress_mutually_exclusive():
     sc = scn.get_scenario("mono")
     ic, run = sc["initial"], sc["run"]
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=ic["V"],
         T0=ic["T0"],
@@ -142,7 +142,7 @@ def test_live_and_progress_mutually_exclusive():
 def test_live_output(capsys):
     sc = scn.get_scenario("mono")
     ic, run = sc["initial"], sc["run"]
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=ic["V"],
         T0=ic["T0"],
@@ -171,7 +171,7 @@ def test_console_output(capsys, caplog):
     caplog.set_level(logging.INFO, logger="pyrcel")
     sc = scn.get_scenario("mono")
     ic, run = sc["initial"], sc["run"]
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=ic["V"],
         T0=ic["T0"],
@@ -191,3 +191,10 @@ def test_console_output(capsys, caplog):
     assert "total activated fraction" in out
     assert "Compiling S_max event solve" in caplog.text
     assert "Termination:" in caplog.text
+
+
+def test_backward_compat_alias():
+    """ParcelModelJAX must remain importable and be identical to ParcelModel."""
+    from pyrcel.model import ParcelModel, ParcelModelJAX
+
+    assert ParcelModelJAX is ParcelModel

--- a/tests/test_netcdf_output.py
+++ b/tests/test_netcdf_output.py
@@ -1,4 +1,4 @@
-"""NetCDF / xarray output writer for ParcelModelJAX (follow-up)."""
+"""NetCDF / xarray output writer for ParcelModel."""
 
 from __future__ import annotations
 
@@ -6,13 +6,13 @@ import numpy as np
 import pytest
 import scenarios as scn
 
-from pyrcel.model import ParcelModelJAX
+from pyrcel.model import ParcelModel
 
 
 def _run_simple():
     sc = scn.get_scenario("simple_sulfate")
     ic, run = sc["initial"], sc["run"]
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=ic["V"],
         T0=ic["T0"],
@@ -44,7 +44,7 @@ def test_to_dataset_structure():
 def test_to_dataset_requires_run():
     sc = scn.get_scenario("simple_sulfate")
     ic = sc["initial"]
-    m = ParcelModelJAX(
+    m = ParcelModel(
         scn.build_aerosols(sc),
         V=ic["V"],
         T0=ic["T0"],


### PR DESCRIPTION
Closes #37.

## Summary

- `ParcelModelJAX` renamed to `ParcelModel` in `pyrcel/model.py`; `ParcelModelJAX` kept as a module-level alias for backward compat (tested with `test_backward_compat_alias`)
- `run()` parameter renamed `output_fmt` → `mode`; `'dataframes'` → `'full'`; `'smax'` and `'arrays'` unchanged
- `'nd'` mode explicitly noted as deferred in the `mode` docstring (kinetic-limitation diagnosis is a future release item)
- `pyrcel/console_report.py` docstring references updated
- `pyrcel/integrator.py` module docstring fixed: self-referential `pyrcel/integrator.py` → `pyrcel/legacy/integrator.py`
- All tests updated; `__init__.py` `_LAZY_ATTRS` intentionally unchanged (that's PR #38)

## Test plan

- [ ] `uv run pytest -q -m "not slow" --ignore=pyrcel/test` → 170 passed
- [ ] `uvx ruff check` / `uvx ruff format --check` → clean
- [ ] Slow tests (`uv run pytest -q --ignore=pyrcel/test`) pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming `run(output_fmt=...)` to `mode` breaks existing v2 callers unless they update kwargs; class rename is mitigated by the `ParcelModelJAX` alias but public lazy exports may still lag (noted as PR #38).
> 
> **Overview**
> Renames the v2 interactive API so **`ParcelModelJAX` becomes `ParcelModel`** (`__all__` and tests/docs in the touched files), with **`ParcelModelJAX = ParcelModel`** left as a module-level alias and covered by **`test_backward_compat_alias`**.
> 
> **`ParcelModel.run()`** renames **`output_fmt` → `mode`**: **`'dataframes'` → `'full'`**; **`'arrays'`** and **`'smax'`** are unchanged. Validation and return branching use the new names, and the docstring notes **`'nd'`** as deferred.
> 
> Doc-only updates align naming with the legacy stack (**`pyrcel.legacy.parcel.ParcelModel`**, legacy integrator path in **`integrator.py`**) and point console output at **`ParcelModel._compute_summary`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41daf756fe949de695734058d56d77d36c5317e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->