### PR TITLE
feat(v2): PEP 561 type annotations + pyrefly type checking (issue #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           uvx ruff format --check pyrcel/ tests/ examples/ tools/
           uvx ruff check pyrcel/ tests/ examples/ tools/
 
-      - name: Type check (pyright)
-        run: uv run pyright
+      - name: Type check (pyrefly)
+        run: uv run pyrefly check
 
       - name: Run fast tests
         run: uv run pytest tests/ -m "not slow" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           uvx ruff format --check pyrcel/ tests/ examples/ tools/
           uvx ruff check pyrcel/ tests/ examples/ tools/
 
+      - name: Type check (pyright)
+        run: uv run pyright
+
       - name: Run fast tests
         run: uv run pytest tests/ -m "not slow" -v
 

--- a/prek.toml
+++ b/prek.toml
@@ -20,10 +20,10 @@ repo = "local"
   types = ["python"]
 
   [[repos.hooks]]
-  id = "pyright"
-  name = "pyright"
+  id = "pyrefly"
+  name = "pyrefly"
   language = "system"
-  entry = "uv run --extra test pyright"
+  entry = "uv run --extra test pyrefly check"
   pass_filenames = false
 
 [[repos]]

--- a/prek.toml
+++ b/prek.toml
@@ -19,6 +19,13 @@ repo = "local"
   entry = "ruff check --fix"
   types = ["python"]
 
+  [[repos.hooks]]
+  id = "pyright"
+  name = "pyright"
+  language = "system"
+  entry = "uv run --extra test pyright"
+  pass_filenames = false
+
 [[repos]]
 repo = "builtin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ gpu = [
 test = [
     "pytest>=7",
     "hypothesis>=6",
+    "pyright>=1.1.380",
 ]
 examples = [
     "matplotlib>=3.5",
@@ -102,6 +103,25 @@ select = ["E", "F", "I", "UP", "NPY"]
 # E402: import order is intentional (sys.path setup, warnings filter before imports)
 "docs/conf.py" = ["E402"]
 "tools/**/*.py" = ["E402", "E501"]
+
+[tool.pyright]
+include = ["pyrcel"]
+exclude = ["pyrcel/legacy", "pyrcel/test", "pyrcel/scripts", "pyrcel/output.py"]
+pythonVersion = "3.11"
+typeCheckingMode = "basic"
+# JAX/equinox/diffrax stubs are incomplete in some areas; suppress the noisiest
+# false-positive categories that arise from those packages rather than our code.
+reportMissingTypeStubs = false
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+reportUnknownArgumentType = false
+reportUnknownParameterType = false
+# jax.typing.ArrayLike is a broad union that includes Python scalars; pyright
+# cannot prove that JAX's dynamic dispatch always produces Array, so arithmetic
+# on ArrayLike arguments and ArrayLike → Array returns trigger false positives.
+reportOperatorIssue = false
+reportReturnType = false
+reportIndexIssue = false
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ gpu = [
 test = [
     "pytest>=7",
     "hypothesis>=6",
-    "pyright>=1.1.380",
+    "pyrefly>=1.1",
 ]
 examples = [
     "matplotlib>=3.5",
@@ -104,25 +104,6 @@ select = ["E", "F", "I", "UP", "NPY"]
 "docs/conf.py" = ["E402"]
 "tools/**/*.py" = ["E402", "E501"]
 
-[tool.pyright]
-include = ["pyrcel"]
-exclude = ["pyrcel/legacy", "pyrcel/test", "pyrcel/scripts", "pyrcel/output.py"]
-pythonVersion = "3.11"
-typeCheckingMode = "basic"
-# JAX/equinox/diffrax stubs are incomplete in some areas; suppress the noisiest
-# false-positive categories that arise from those packages rather than our code.
-reportMissingTypeStubs = false
-reportUnknownMemberType = false
-reportUnknownVariableType = false
-reportUnknownArgumentType = false
-reportUnknownParameterType = false
-# jax.typing.ArrayLike is a broad union that includes Python scalars; pyright
-# cannot prove that JAX's dynamic dispatch always produces Array, so arithmetic
-# on ArrayLike arguments and ArrayLike → Array returns trigger false positives.
-reportOperatorIssue = false
-reportReturnType = false
-reportIndexIssue = false
-
 [tool.pytest.ini_options]
 markers = [
     "slow: full JAX/diffrax integration, autodiff, or ensemble solve (skip locally with -m 'not slow')",
@@ -130,3 +111,31 @@ markers = [
 filterwarnings = [
     "ignore:invalid value encountered in scalar divide:RuntimeWarning:pyrcel.legacy.activation",
 ]
+
+[tool.pyrefly]
+project-includes = ["pyrcel"]
+project-excludes = [
+    "pyrcel/legacy",
+    "pyrcel/test",
+    "pyrcel/scripts",
+    "pyrcel/output.py",
+]
+python-version = "3.11.0"
+infer-with-first-use = false
+
+[tool.pyrefly.errors]
+# JAX/equinox/diffrax stubs are incomplete in some areas; suppress the noisiest
+# false-positive categories that arise from those packages rather than our code.
+# untyped-import: third-party JAX ecosystem packages lack complete stubs.
+# bad-index / unsupported-operation: ArrayLike includes Python scalars; pyrefly
+#   cannot prove JAX's dynamic dispatch always produces an indexable Array.
+# implicit-any / implicit-any-parameter: accepted in JAX-heavy code where Any
+#   leaks from untyped diffrax/equinox/optimistix callsites.
+# bad-return: ArrayLike arithmetic on ArrayLike inputs produces non-Array types
+#   in pyrefly's view, even though JAX always dispatches to Array at runtime.
+untyped-import = "ignore"
+bad-index = "ignore"
+implicit-any = "ignore"
+bad-return = "ignore"
+unsupported-operation = "ignore"
+implicit-any-parameter = "ignore"

--- a/pyrcel/_types.py
+++ b/pyrcel/_types.py
@@ -1,0 +1,12 @@
+"""Shared type aliases for pyrcel's public and internal APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+# Accepts a Python scalar or a NumPy array of any floating dtype.
+# Used for distribution pdf/cdf inputs and outputs that may be either.
+FloatND = float | NDArray[np.floating[Any]]

--- a/pyrcel/activation/_arg2000.py
+++ b/pyrcel/activation/_arg2000.py
@@ -22,6 +22,10 @@ from jax import Array  # noqa: E402
 from jax.scipy.special import erfc  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
 
+# Alias used in per-mode parameter signatures to signal that all arguments
+# sharing this type must have the same length (n_modes,).
+_ModeParam = ArrayLike
+
 from .. import constants as c  # noqa: E402
 from ..thermo import dv, dv_cont, es, ka_cont, sigma_w  # noqa: E402
 
@@ -74,10 +78,10 @@ def arg2000(
     V: ArrayLike,
     T: ArrayLike,
     P: ArrayLike,
-    mus: ArrayLike,
-    sigmas: ArrayLike,
-    Ns: ArrayLike,
-    kappas: ArrayLike,
+    mus: _ModeParam,
+    sigmas: _ModeParam,
+    Ns: _ModeParam,
+    kappas: _ModeParam,
     accom: float = c.ac,
 ) -> tuple[Array, Array, Array]:
     """JAX-native Abdul-Razzak & Ghan (2000) activation parameterization.
@@ -204,10 +208,10 @@ class ARG2000:
         V: ArrayLike,
         T: ArrayLike,
         P: ArrayLike,
-        mus: ArrayLike,
-        sigmas: ArrayLike,
-        Ns: ArrayLike,
-        kappas: ArrayLike,
+        mus: _ModeParam,
+        sigmas: _ModeParam,
+        Ns: _ModeParam,
+        kappas: _ModeParam,
         accom: float | None = None,
     ) -> tuple[Array, Array, Array]:
         return arg2000(

--- a/pyrcel/activation/_arg2000.py
+++ b/pyrcel/activation/_arg2000.py
@@ -22,10 +22,6 @@ from jax import Array  # noqa: E402
 from jax.scipy.special import erfc  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
 
-# Alias used in per-mode parameter signatures to signal that all arguments
-# sharing this type must have the same length (n_modes,).
-_ModeParam = ArrayLike
-
 from .. import constants as c  # noqa: E402
 from ..thermo import dv, dv_cont, es, ka_cont, sigma_w  # noqa: E402
 
@@ -78,10 +74,10 @@ def arg2000(
     V: ArrayLike,
     T: ArrayLike,
     P: ArrayLike,
-    mus: _ModeParam,
-    sigmas: _ModeParam,
-    Ns: _ModeParam,
-    kappas: _ModeParam,
+    mus: ArrayLike,
+    sigmas: ArrayLike,
+    Ns: ArrayLike,
+    kappas: ArrayLike,
     accom: float = c.ac,
 ) -> tuple[Array, Array, Array]:
     """JAX-native Abdul-Razzak & Ghan (2000) activation parameterization.
@@ -208,10 +204,10 @@ class ARG2000:
         V: ArrayLike,
         T: ArrayLike,
         P: ArrayLike,
-        mus: _ModeParam,
-        sigmas: _ModeParam,
-        Ns: _ModeParam,
-        kappas: _ModeParam,
+        mus: ArrayLike,
+        sigmas: ArrayLike,
+        Ns: ArrayLike,
+        kappas: ArrayLike,
         accom: float | None = None,
     ) -> tuple[Array, Array, Array]:
         return arg2000(

--- a/pyrcel/activation/_arg2000.py
+++ b/pyrcel/activation/_arg2000.py
@@ -18,13 +18,15 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
+from jax import Array  # noqa: E402
 from jax.scipy.special import erfc  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
 
 from .. import constants as c  # noqa: E402
 from ..thermo import dv, dv_cont, es, ka_cont, sigma_w  # noqa: E402
 
 
-def _kohler_crit_approx(T, r_dry, kappa):
+def _kohler_crit_approx(T: ArrayLike, r_dry: ArrayLike, kappa: ArrayLike) -> tuple[Array, Array]:
     """Approximate critical radius and supersaturation (JAX-traceable, kappa > 0).
 
     Returns
@@ -40,7 +42,9 @@ def _kohler_crit_approx(T, r_dry, kappa):
     return r_crit, s_crit
 
 
-def _lognormal_act(smax, sigma, N, sgi):
+def _lognormal_act(
+    smax: ArrayLike, sigma: ArrayLike, N: ArrayLike, sgi: ArrayLike
+) -> tuple[Array, Array]:
     """Activated fraction of one lognormal mode.
 
     Parameters
@@ -66,7 +70,16 @@ def _lognormal_act(smax, sigma, N, sgi):
     return N_act, N_act / N
 
 
-def arg2000(V, T, P, mus, sigmas, Ns, kappas, accom=c.ac):
+def arg2000(
+    V: ArrayLike,
+    T: ArrayLike,
+    P: ArrayLike,
+    mus: ArrayLike,
+    sigmas: ArrayLike,
+    Ns: ArrayLike,
+    kappas: ArrayLike,
+    accom: float = c.ac,
+) -> tuple[Array, Array, Array]:
     """JAX-native Abdul-Razzak & Ghan (2000) activation parameterization.
 
     A faithful JAX re-implementation of :func:`pyrcel.legacy.activation.arg2000`.
@@ -183,13 +196,23 @@ class ARG2000:
         Condensation accommodation coefficient (forwarded to every call).
     """
 
-    def __init__(self, accom=c.ac):
+    def __init__(self, accom: float = c.ac) -> None:
         self.accom = accom
 
-    def __call__(self, V, T, P, mus, sigmas, Ns, kappas, accom=None):
+    def __call__(
+        self,
+        V: ArrayLike,
+        T: ArrayLike,
+        P: ArrayLike,
+        mus: ArrayLike,
+        sigmas: ArrayLike,
+        Ns: ArrayLike,
+        kappas: ArrayLike,
+        accom: float | None = None,
+    ) -> tuple[Array, Array, Array]:
         return arg2000(
             V, T, P, mus, sigmas, Ns, kappas, accom=self.accom if accom is None else accom
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ARG2000(accom={self.accom})"

--- a/pyrcel/activation/_scheme.py
+++ b/pyrcel/activation/_scheme.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from .. import constants as c
+
+if TYPE_CHECKING:
+    from jax import Array
+    from jax.typing import ArrayLike
 
 
 class ActivationScheme(ABC):
@@ -17,7 +22,17 @@ class ActivationScheme(ABC):
     """
 
     @abstractmethod
-    def __call__(self, V, T, P, mus, sigmas, Ns, kappas, accom=c.ac):
+    def __call__(
+        self,
+        V: ArrayLike,
+        T: ArrayLike,
+        P: ArrayLike,
+        mus: ArrayLike,
+        sigmas: ArrayLike,
+        Ns: ArrayLike,
+        kappas: ArrayLike,
+        accom: float = c.ac,
+    ) -> tuple[Array, Array, Array]:
         """Predict maximum supersaturation and activated fractions.
 
         Parameters

--- a/pyrcel/activation/_scheme.py
+++ b/pyrcel/activation/_scheme.py
@@ -11,10 +11,6 @@ if TYPE_CHECKING:
     from jax import Array
     from jax.typing import ArrayLike
 
-    # Per-mode parameter: all arguments annotated with this type must share
-    # the same length (n_modes,).
-    _ModeParam = ArrayLike
-
 
 class ActivationScheme(ABC):
     """Interface for droplet activation parameterizations.
@@ -31,10 +27,10 @@ class ActivationScheme(ABC):
         V: ArrayLike,
         T: ArrayLike,
         P: ArrayLike,
-        mus: _ModeParam,
-        sigmas: _ModeParam,
-        Ns: _ModeParam,
-        kappas: _ModeParam,
+        mus: ArrayLike,
+        sigmas: ArrayLike,
+        Ns: ArrayLike,
+        kappas: ArrayLike,
         accom: float = c.ac,
     ) -> tuple[Array, Array, Array]:
         """Predict maximum supersaturation and activated fractions.

--- a/pyrcel/activation/_scheme.py
+++ b/pyrcel/activation/_scheme.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
     from jax import Array
     from jax.typing import ArrayLike
 
+    # Per-mode parameter: all arguments annotated with this type must share
+    # the same length (n_modes,).
+    _ModeParam = ArrayLike
+
 
 class ActivationScheme(ABC):
     """Interface for droplet activation parameterizations.
@@ -27,10 +31,10 @@ class ActivationScheme(ABC):
         V: ArrayLike,
         T: ArrayLike,
         P: ArrayLike,
-        mus: ArrayLike,
-        sigmas: ArrayLike,
-        Ns: ArrayLike,
-        kappas: ArrayLike,
+        mus: _ModeParam,
+        sigmas: _ModeParam,
+        Ns: _ModeParam,
+        kappas: _ModeParam,
         accom: float = c.ac,
     ) -> tuple[Array, Array, Array]:
         """Predict maximum supersaturation and activated fractions.

--- a/pyrcel/aerosol.py
+++ b/pyrcel/aerosol.py
@@ -1,11 +1,16 @@
 """Container class for encapsulating data about aerosol size distributions."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
+from numpy.typing import NDArray
 
 from .distributions import BaseDistribution, Lognorm, MultiModeLognorm
 
 
-def dist_to_conc(dist, r_min, r_max, rule="trapezoid"):
+def dist_to_conc(dist: BaseDistribution, r_min: float, r_max: float, rule: str = "trapezoid") -> float:
     """Convert a size distribution over a bin interval to a number concentration.
 
     Aerosol size distributions are typically reported as dN/dr (number density
@@ -157,15 +162,15 @@ class AerosolSpecies:
 
     def __init__(
         self,
-        species,
-        distribution,
-        kappa,
-        rho=None,
-        mw=None,
-        bins=None,
-        r_min=None,
-        r_max=None,
-    ):
+        species: str,
+        distribution: BaseDistribution | dict[str, Any],
+        kappa: float,
+        rho: float | None = None,
+        mw: float | None = None,
+        bins: int | NDArray[np.floating[Any]] | None = None,
+        r_min: float | None = None,
+        r_max: float | None = None,
+    ) -> None:
         self.species = species
         self.kappa = kappa
         self.rho = rho
@@ -228,7 +233,7 @@ class AerosolSpecies:
         self.Nis = self.Nis * 1e6
         self.nr = len(self.r_drys)
 
-    def stats(self):
+    def stats(self) -> dict[str, float]:
         """Compute useful statistics about this aerosol's size distribution.
 
         Returns
@@ -260,11 +265,11 @@ class AerosolSpecies:
 
         return stats_dict
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"AerosolSpecies({self.species!r}, kappa={self.kappa}, "
             f"distribution={self.distribution!r})"
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.species}: kappa={self.kappa:.3f}, N={self.total_N:.1f} cm⁻³, nr={self.nr}"

--- a/pyrcel/aerosol.py
+++ b/pyrcel/aerosol.py
@@ -10,7 +10,9 @@ from numpy.typing import NDArray
 from .distributions import BaseDistribution, Lognorm, MultiModeLognorm
 
 
-def dist_to_conc(dist: BaseDistribution, r_min: float, r_max: float, rule: str = "trapezoid") -> float:
+def dist_to_conc(
+    dist: BaseDistribution, r_min: float, r_max: float, rule: str = "trapezoid"
+) -> float:
     """Convert a size distribution over a bin interval to a number concentration.
 
     Aerosol size distributions are typically reported as dN/dr (number density

--- a/pyrcel/aerosol.py
+++ b/pyrcel/aerosol.py
@@ -191,7 +191,7 @@ class AerosolSpecies:
                     rs.append(r**2.0 / rs[-1])
                 self.rs = np.array(rs) * 1e6
             else:
-                self.rs = None  # monodisperse; no bin edges needed
+                self.rs = None  # pyrefly: ignore[bad-assignment]  # monodisperse; no bin edges needed
 
             self.Nis = np.array(distribution["Nis"])
 

--- a/pyrcel/distributions.py
+++ b/pyrcel/distributions.py
@@ -10,24 +10,22 @@ describe droplet size distributions or other collections of objects.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
 from scipy.special import erf, erfinv
 
-_Float = float | NDArray[np.floating[Any]]
+from ._types import FloatND
 
 
 class BaseDistribution(metaclass=ABCMeta):
     """Interface for distributions, to ensure that they contain a pdf method."""
 
     @abstractmethod
-    def cdf(self, x: _Float) -> _Float:
+    def cdf(self, x: FloatND) -> FloatND:
         """Cumulative density function"""
 
     @abstractmethod
-    def pdf(self, x: _Float) -> _Float:
+    def pdf(self, x: FloatND) -> FloatND:
         """Distribution density function."""
 
     @abstractmethod
@@ -96,7 +94,7 @@ class Lognorm(BaseDistribution):
         # Arithmetic mean of the underlying normal: E[r] = mu * exp(0.5 * ln(sigma)^2)
         self.mean = self.mu * np.exp(0.5 * np.log(self.sigma) ** 2)
 
-    def invcdf(self, y: _Float) -> _Float:
+    def invcdf(self, y: FloatND) -> FloatND:
         """Inverse of cumulative density function.
 
         Parameters
@@ -117,7 +115,7 @@ class Lognorm(BaseDistribution):
         erfinv_arg = 2.0 * y / self.N - 1.0
         return self.mu * np.exp(np.log(self.sigma) * np.sqrt(2.0) * erfinv(erfinv_arg))
 
-    def cdf(self, x: _Float) -> _Float:
+    def cdf(self, x: FloatND) -> FloatND:
         """Cumulative density function
 
         .. math::
@@ -137,7 +135,7 @@ class Lognorm(BaseDistribution):
         erf_arg = (np.log(x / self.mu)) / (np.sqrt(2.0) * np.log(self.sigma))
         return (self.N / 2.0) * (1.0 + erf(erf_arg))
 
-    def pdf(self, x: _Float) -> _Float:
+    def pdf(self, x: FloatND) -> FloatND:
         """Distribution density function dN/dx (not logarithmic).
 
         .. math::
@@ -158,7 +156,7 @@ class Lognorm(BaseDistribution):
         exponent = ((np.log(x / self.mu)) ** 2) / (2.0 * (np.log(self.sigma)) ** 2)
         return (scaling / x) * np.exp(-exponent)
 
-    def pdfloge(self, x: _Float) -> _Float:
+    def pdfloge(self, x: FloatND) -> FloatND:
         """Distribution density function dN/dln(x) (natural logarithm).
 
         .. math::
@@ -179,7 +177,7 @@ class Lognorm(BaseDistribution):
         exponent = ((np.log(x / self.mu)) ** 2) / (2.0 * (np.log(self.sigma)) ** 2)
         return scaling * np.exp(-exponent)
 
-    def pdflog10(self, x: _Float) -> _Float:
+    def pdflog10(self, x: FloatND) -> FloatND:
         """Distribution density function dN/dlog(x) (base 10 logarithm).
 
         .. math::
@@ -280,10 +278,10 @@ class MultiModeLognorm(BaseDistribution):
             mode_dist = Lognorm(mu, sigma, N)
             self.lognorms.append(mode_dist)
 
-    def cdf(self, x: _Float) -> _Float:
+    def cdf(self, x: FloatND) -> FloatND:
         return np.sum([d.cdf(x) for d in self.lognorms], axis=0)
 
-    def pdf(self, x: _Float) -> _Float:
+    def pdf(self, x: FloatND) -> FloatND:
         return np.sum([d.pdf(x) for d in self.lognorms], axis=0)
 
     def stats(self) -> dict[str, float]:

--- a/pyrcel/distributions.py
+++ b/pyrcel/distributions.py
@@ -7,30 +7,35 @@ describe droplet size distributions or other collections of objects.
 
 """
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy.special import erf, erfinv
+
+_Float = float | NDArray[np.floating[Any]]
 
 
 class BaseDistribution(metaclass=ABCMeta):
     """Interface for distributions, to ensure that they contain a pdf method."""
 
     @abstractmethod
-    def cdf(self, x):
+    def cdf(self, x: _Float) -> _Float:
         """Cumulative density function"""
 
     @abstractmethod
-    def pdf(self, x):
+    def pdf(self, x: _Float) -> _Float:
         """Distribution density function."""
 
-    @property
     @abstractmethod
-    def stats(self):
+    def stats(self) -> dict[str, float]:
         pass
 
     @abstractmethod
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Representation function."""
 
 
@@ -82,7 +87,7 @@ class Lognorm(BaseDistribution):
 
     """
 
-    def __init__(self, mu, sigma, N=1.0, base=np.e):
+    def __init__(self, mu: float, sigma: float, N: float = 1.0, base: float = np.e) -> None:
         self.mu = mu
         self.sigma = sigma
         self.N = N
@@ -91,7 +96,7 @@ class Lognorm(BaseDistribution):
         # Arithmetic mean of the underlying normal: E[r] = mu * exp(0.5 * ln(sigma)^2)
         self.mean = self.mu * np.exp(0.5 * np.log(self.sigma) ** 2)
 
-    def invcdf(self, y):
+    def invcdf(self, y: _Float) -> _Float:
         """Inverse of cumulative density function.
 
         Parameters
@@ -112,7 +117,7 @@ class Lognorm(BaseDistribution):
         erfinv_arg = 2.0 * y / self.N - 1.0
         return self.mu * np.exp(np.log(self.sigma) * np.sqrt(2.0) * erfinv(erfinv_arg))
 
-    def cdf(self, x):
+    def cdf(self, x: _Float) -> _Float:
         """Cumulative density function
 
         .. math::
@@ -132,7 +137,7 @@ class Lognorm(BaseDistribution):
         erf_arg = (np.log(x / self.mu)) / (np.sqrt(2.0) * np.log(self.sigma))
         return (self.N / 2.0) * (1.0 + erf(erf_arg))
 
-    def pdf(self, x):
+    def pdf(self, x: _Float) -> _Float:
         """Distribution density function dN/dx (not logarithmic).
 
         .. math::
@@ -153,7 +158,7 @@ class Lognorm(BaseDistribution):
         exponent = ((np.log(x / self.mu)) ** 2) / (2.0 * (np.log(self.sigma)) ** 2)
         return (scaling / x) * np.exp(-exponent)
 
-    def pdfloge(self, x):
+    def pdfloge(self, x: _Float) -> _Float:
         """Distribution density function dN/dln(x) (natural logarithm).
 
         .. math::
@@ -174,7 +179,7 @@ class Lognorm(BaseDistribution):
         exponent = ((np.log(x / self.mu)) ** 2) / (2.0 * (np.log(self.sigma)) ** 2)
         return scaling * np.exp(-exponent)
 
-    def pdflog10(self, x):
+    def pdflog10(self, x: _Float) -> _Float:
         """Distribution density function dN/dlog(x) (base 10 logarithm).
 
         .. math::
@@ -195,7 +200,7 @@ class Lognorm(BaseDistribution):
         exponent = ((np.log(x / self.mu)) ** 2) / (2.0 * (np.log(self.sigma)) ** 2)
         return np.log(10) * scaling * np.exp(-exponent)
 
-    def moment(self, k):
+    def moment(self, k: int | float) -> float:
         """Compute the k-th moment of the lognormal distribution.
 
         .. math::
@@ -216,7 +221,7 @@ class Lognorm(BaseDistribution):
         exponent = ((k**2) / 2.0) * (np.log(self.sigma)) ** 2
         return scaling * np.exp(exponent)
 
-    def stats(self):
+    def stats(self) -> dict[str, float]:
         """Compute useful statistics for a lognormal distribution
 
         Returns
@@ -243,7 +248,7 @@ class Lognorm(BaseDistribution):
 
         return stats_dict
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Lognorm | mu = {self.mu:2.2e}, sigma = {self.sigma:2.2e}, Total = {self.N:2.2e} |"
 
 
@@ -254,7 +259,13 @@ class MultiModeLognorm(BaseDistribution):
     distribution.
     """
 
-    def __init__(self, mus, sigmas, Ns, base=np.e):
+    def __init__(
+        self,
+        mus: tuple[float, ...] | list[float],
+        sigmas: tuple[float, ...] | list[float],
+        Ns: tuple[float, ...] | list[float],
+        base: float = np.e,
+    ) -> None:
         dist_params = list(zip(mus, sigmas, Ns))
         from operator import itemgetter
 
@@ -269,20 +280,20 @@ class MultiModeLognorm(BaseDistribution):
             mode_dist = Lognorm(mu, sigma, N)
             self.lognorms.append(mode_dist)
 
-    def cdf(self, x):
+    def cdf(self, x: _Float) -> _Float:
         return np.sum([d.cdf(x) for d in self.lognorms], axis=0)
 
-    def pdf(self, x):
+    def pdf(self, x: _Float) -> _Float:
         return np.sum([d.pdf(x) for d in self.lognorms], axis=0)
 
-    def stats(self):
+    def stats(self) -> dict[str, float]:
         """Compute useful statistics for a multi-mode lognormal distribution
 
         TODO: Implement multi-mode lognorm stats
         """
         raise NotImplementedError()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         mus_str = "(" + ", ".join("%2.2e" % mu for mu in self.mus) + ")"
         sigmas_str = "(" + ", ".join("%2.2e" % sigma for sigma in self.sigmas) + ")"
         Ns_str = "(" + ", ".join("%2.2e" % N for N in self.Ns) + ")"

--- a/pyrcel/ensemble.py
+++ b/pyrcel/ensemble.py
@@ -14,8 +14,11 @@ very different times-to-peak) are handled correctly within one ``vmap``.
 
 from __future__ import annotations
 
+from typing import Any
+
 import jax
 import numpy as np
+from numpy.typing import NDArray
 
 jax.config.update("jax_enable_x64", True)
 
@@ -29,7 +32,9 @@ from .updraft import ConstantV  # noqa: E402
 __all__ = ["sample_gaussian_updrafts", "smax_nact_ensemble", "run_updraft_ensemble"]
 
 
-def sample_gaussian_updrafts(mean, std, n, *, seed=0, v_min=1e-2):
+def sample_gaussian_updrafts(
+    mean: float, std: float, n: int, *, seed: int = 0, v_min: float = 1e-2
+) -> NDArray[np.floating[Any]]:
     """Draw ``n`` updraft speeds from ``Normal(mean, std)`` (m/s).
 
     Samples are clipped at ``v_min`` so every member is a physical (positive) updraft;
@@ -41,18 +46,18 @@ def sample_gaussian_updrafts(mean, std, n, *, seed=0, v_min=1e-2):
 
 
 def smax_nact_ensemble(
-    y0,
-    r_drys,
-    Nis,
-    kappas,
-    accom,
-    V_samples,
-    t_end,
+    y0: Any,
+    r_drys: Any,
+    Nis: Any,
+    kappas: Any,
+    accom: float,
+    V_samples: Any,
+    t_end: float,
     *,
-    rtol=STATE_RTOL,
-    atol=None,
-    max_steps=100_000,
-):
+    rtol: float = STATE_RTOL,
+    atol: Any = None,
+    max_steps: int = 100_000,
+) -> dict[str, Any]:
     """Peak supersaturation and activated number for a batch of updraft speeds.
 
     Parameters
@@ -108,21 +113,21 @@ def smax_nact_ensemble(
 
 
 def run_updraft_ensemble(
-    aerosols,
-    T0,
-    S0,
-    P0,
+    aerosols: list[Any],
+    T0: float,
+    S0: float,
+    P0: float,
     *,
-    mean,
-    std,
-    n,
-    seed=0,
-    v_min=1e-2,
-    accom=c.ac,
-    z_cap=400.0,
-    t_end=None,
-    max_steps=100_000,
-):
+    mean: float,
+    std: float,
+    n: int,
+    seed: int = 0,
+    v_min: float = 1e-2,
+    accom: float = c.ac,
+    z_cap: float = 400.0,
+    t_end: float | None = None,
+    max_steps: int = 100_000,
+) -> dict[str, Any]:
     """Convenience: sample a Gaussian updraft distribution and run the ensemble.
 
     Equilibrates ``y0`` once for the given aerosols/conditions, samples ``n`` updraft

--- a/pyrcel/ensemble.py
+++ b/pyrcel/ensemble.py
@@ -23,6 +23,7 @@ from numpy.typing import NDArray
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
 
 from . import constants as c  # noqa: E402
 from .equilibrate import equilibrate_initial_state, kohler_crit_approx  # noqa: E402
@@ -46,18 +47,18 @@ def sample_gaussian_updrafts(
 
 
 def smax_nact_ensemble(
-    y0: Any,
-    r_drys: Any,
-    Nis: Any,
-    kappas: Any,
+    y0: ArrayLike,
+    r_drys: ArrayLike,
+    Nis: ArrayLike,
+    kappas: ArrayLike,
     accom: float,
-    V_samples: Any,
+    V_samples: ArrayLike,
     t_end: float,
     *,
     rtol: float = STATE_RTOL,
-    atol: Any = None,
+    atol: ArrayLike | None = None,
     max_steps: int = 100_000,
-) -> dict[str, Any]:
+) -> dict[str, NDArray[np.floating[Any]] | NDArray[np.bool_] | float]:
     """Peak supersaturation and activated number for a batch of updraft speeds.
 
     Parameters

--- a/pyrcel/equilibrate.py
+++ b/pyrcel/equilibrate.py
@@ -120,7 +120,7 @@ def kohler_crit(
     kohler_crit_approx : Analytic approximation.
     pyrcel.legacy.thermo.kohler_crit : NumPy equivalent using ``scipy.optimize.fminbound``.
     """
-    solver = optx.Bisection(rtol=rtol, atol=atol, expand_if_necessary=True)
+    solver = optx.Bisection(rtol=rtol, atol=atol, expand_if_necessary=True)  # pyrefly: ignore[missing-argument]
 
     def dseq_dr(r, args):
         rd, kap = args
@@ -169,7 +169,7 @@ def equilibrate_radii(
     """
     r_drys = jnp.asarray(r_drys)
     kappas = jnp.asarray(kappas)
-    solver = optx.Bisection(rtol=rtol, atol=atol, expand_if_necessary=True)
+    solver = optx.Bisection(rtol=rtol, atol=atol, expand_if_necessary=True)  # pyrefly: ignore[missing-argument]
 
     def residual(r, args):
         r_dry, kappa = args

--- a/pyrcel/equilibrate.py
+++ b/pyrcel/equilibrate.py
@@ -25,6 +25,8 @@ Per the locked decision, gradients are required through the *integration* w.r.t.
 
 from __future__ import annotations
 
+from typing import Any
+
 import jax
 
 jax.config.update("jax_enable_x64", True)
@@ -33,7 +35,6 @@ import jax.numpy as jnp  # noqa: E402
 import optimistix as optx  # noqa: E402
 from jax import Array  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
-from typing import Any  # noqa: E402
 
 from . import constants as c  # noqa: E402
 from .thermo import Seq, es, rho_air, sigma_w  # noqa: E402

--- a/pyrcel/equilibrate.py
+++ b/pyrcel/equilibrate.py
@@ -31,6 +31,9 @@ jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
 import optimistix as optx  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
+from typing import Any  # noqa: E402
 
 from . import constants as c  # noqa: E402
 from .thermo import Seq, es, rho_air, sigma_w  # noqa: E402
@@ -42,7 +45,7 @@ _ATOL = 1e-30
 _MAX_STEPS = 200
 
 
-def kohler_crit_approx(T, r_dry, kappa):
+def kohler_crit_approx(T: ArrayLike, r_dry: ArrayLike, kappa: ArrayLike) -> tuple[Array, Array]:
     """Analytic approximate Köhler critical radius and supersaturation.
 
     Mirrors :func:`pyrcel.legacy.thermo.kohler_crit` with ``approx=True``. This
@@ -77,7 +80,15 @@ def kohler_crit_approx(T, r_dry, kappa):
     return r_crit, s_crit
 
 
-def kohler_crit(T, r_dry, kappa, *, rtol=_RTOL, atol=_ATOL, max_steps=_MAX_STEPS):
+def kohler_crit(
+    T: ArrayLike,
+    r_dry: ArrayLike,
+    kappa: ArrayLike,
+    *,
+    rtol: float = _RTOL,
+    atol: float = _ATOL,
+    max_steps: int = _MAX_STEPS,
+) -> Array:
     """Exact Köhler critical (peak) radius via a root-find on ``dSeq/dr = 0``.
 
     The JAX analog of ``pyrcel.legacy.thermo.kohler_crit`` (which uses
@@ -130,7 +141,16 @@ def kohler_crit(T, r_dry, kappa, *, rtol=_RTOL, atol=_ATOL, max_steps=_MAX_STEPS
     return sol.value
 
 
-def equilibrate_radii(T0, S0, r_drys, kappas, *, rtol=_RTOL, atol=_ATOL, max_steps=_MAX_STEPS):
+def equilibrate_radii(
+    T0: float,
+    S0: float,
+    r_drys: ArrayLike,
+    kappas: ArrayLike,
+    *,
+    rtol: float = _RTOL,
+    atol: float = _ATOL,
+    max_steps: int = _MAX_STEPS,
+) -> Array:
     """Equilibrium wet radii for every aerosol bin (vectorized over bins).
 
     Parameters
@@ -174,7 +194,15 @@ def equilibrate_radii(T0, S0, r_drys, kappas, *, rtol=_RTOL, atol=_ATOL, max_ste
     return jax.vmap(solve_one)(r_drys, kappas)
 
 
-def equilibrate_initial_state(T0, S0, P0, r_drys, kappas, Nis, **kwargs):
+def equilibrate_initial_state(
+    T0: float,
+    S0: float,
+    P0: float,
+    r_drys: ArrayLike,
+    kappas: ArrayLike,
+    Nis: ArrayLike,
+    **kwargs: Any,
+) -> Array:
     """Assemble the equilibrated initial state vector ``y0``.
 
     Faithful to ``ParcelModel._setup_run``: water-vapor mixing ratio from the

--- a/pyrcel/integrator.py
+++ b/pyrcel/integrator.py
@@ -18,6 +18,7 @@ This is the differentiable/batchable numerical core: it is a pure function of
 from __future__ import annotations
 
 import functools
+from typing import Any
 
 import jax
 
@@ -29,7 +30,6 @@ import numpy as np  # noqa: E402
 import optimistix as optx  # noqa: E402
 from jax import Array  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
-from typing import Any  # noqa: E402
 
 from .parcel_aux import N_STATE_VARS, parcel_ode_sys  # noqa: E402
 from .updraft import ConstantV  # noqa: E402

--- a/pyrcel/integrator.py
+++ b/pyrcel/integrator.py
@@ -27,6 +27,9 @@ import diffrax as dfx  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import optimistix as optx  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
+from typing import Any  # noqa: E402
 
 from .parcel_aux import N_STATE_VARS, parcel_ode_sys  # noqa: E402
 from .updraft import ConstantV  # noqa: E402
@@ -39,7 +42,7 @@ RADIUS_ATOL = 1e-12
 _TERM = dfx.ODETerm(parcel_ode_sys)
 
 
-def atol_vector(nr: int) -> jnp.ndarray:
+def atol_vector(nr: int) -> Array:
     """Build the per-component absolute tolerance vector for the ODE solver.
 
     Parameters
@@ -76,16 +79,16 @@ def _solve(y0, args, ts, rtol, atol, dtmax, max_steps, progress_meter=dfx.NoProg
 
 
 def integrate_parcel(
-    y0,
-    args,
-    ts,
+    y0: ArrayLike,
+    args: tuple,
+    ts: ArrayLike,
     *,
     rtol: float = STATE_RTOL,
-    atol=None,
+    atol: ArrayLike | None = None,
     dtmax: float | None = None,
     max_steps: int = 100_000,
-    progress_meter=None,
-):
+    progress_meter: dfx.AbstractProgressMeter | None = None,
+) -> dfx.Solution:
     """Integrate the parcel ODE and return the full ``diffrax`` solution.
 
     Parameters
@@ -123,7 +126,9 @@ def integrate_parcel(
     return _solve(y0, args, ts, rtol, atol, dtmax, max_steps, progress_meter)
 
 
-def integrate_parcel_arrays(y0, args, ts, **kwargs):
+def integrate_parcel_arrays(
+    y0: ArrayLike, args: tuple, ts: ArrayLike, **kwargs: Any
+) -> tuple[Array, Array, bool]:
     """Integrate the parcel ODE and return raw arrays.
 
     Convenience wrapper around :func:`integrate_parcel` that unpacks the
@@ -157,7 +162,15 @@ def integrate_parcel_arrays(y0, args, ts, **kwargs):
 # --- Differentiable diagnostics (design §5.3, §7.6) ------------------------------
 
 
-def max_supersaturation(y0, args, ts, *, rtol=STATE_RTOL, atol=None, max_steps=100_000):
+def max_supersaturation(
+    y0: ArrayLike,
+    args: tuple,
+    ts: ArrayLike,
+    *,
+    rtol: float = STATE_RTOL,
+    atol: ArrayLike | None = None,
+    max_steps: int = 100_000,
+) -> Array:
     """Peak supersaturation over the output grid, as a differentiable scalar.
 
     A fixed-horizon solve (no data-dependent event) so the whole computation is a
@@ -529,6 +542,7 @@ def integrate_parcel_chunked(
             ts_parts.append(ts)
             ys_parts.append(ys)
 
+        assert sol.ys is not None
         y_curr = sol.ys[-1]
         t_curr = float(ts[-1])
 

--- a/pyrcel/model.py
+++ b/pyrcel/model.py
@@ -19,6 +19,9 @@ inner vector field / updraft are Equinox modules.
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import numpy as np
 
 from . import constants as c
@@ -71,7 +74,16 @@ class ParcelModel:
     available immediately as :attr:`y0`.
     """
 
-    def __init__(self, aerosols, V, T0, S0, P0, accom=c.ac, console=False):
+    def __init__(
+        self,
+        aerosols: list,
+        V: float | AbstractUpdraft,
+        T0: float,
+        S0: float,
+        P0: float,
+        accom: float = c.ac,
+        console: bool = False,
+    ) -> None:
         self.aerosols = list(aerosols)
         self.V = V
         self.T0 = float(T0)
@@ -134,18 +146,18 @@ class ParcelModel:
 
     def run(
         self,
-        t_end,
-        output_dt=1.0,
+        t_end: float,
+        output_dt: float = 1.0,
         *,
-        terminate=True,
-        terminate_depth=10.0,
-        max_steps=100_000,
-        progress=False,
-        live=False,
-        live_chunk_dt=10.0,
-        trajectory_table=None,
-        mode="full",
-    ):
+        terminate: bool = True,
+        terminate_depth: float = 10.0,
+        max_steps: int = 100_000,
+        progress: bool = False,
+        live: bool = False,
+        live_chunk_dt: float = 10.0,
+        trajectory_table: bool | None = None,
+        mode: str = "full",
+    ) -> ModelOutput | float:
         """Run the simulation.
 
         Parameters
@@ -348,7 +360,9 @@ class ParcelModel:
 
     # --- diagnostics --------------------------------------------------------------
 
-    def _compute_summary(self, peak=None) -> dict:
+    def _compute_summary(self, peak: object = None) -> dict:
+        assert self.x is not None
+        assert self.time is not None
         S = self.x[:, c.STATE_VAR_MAP["S"]]
         if peak is not None:
             # Use the event-localized (precise) S_max/t_smax; take droplet radii from
@@ -401,7 +415,7 @@ class ParcelModel:
     # --- output formatting (delegates to ModelOutput) ----------------------------
 
     def _make_output(self) -> ModelOutput:
-        if self.x is None:
+        if self.x is None or self.time is None or self._summary is None:
             raise RuntimeError("call run() before accessing output")
         return ModelOutput(
             time=self.time,
@@ -415,14 +429,14 @@ class ParcelModel:
             accom=self.accom,
         )
 
-    def to_dataset(self):
+    def to_dataset(self) -> Any:
         """Return a CF-flavoured :class:`xarray.Dataset`.
 
         Delegates to :meth:`~pyrcel.model_output.ModelOutput.to_xarray`.
         """
         return self._make_output().to_xarray()
 
-    def save_netcdf(self, filename):
+    def save_netcdf(self, filename: str | Path) -> str | Path:
         """Write the run to a NetCDF file (see :meth:`to_dataset`)."""
         self._make_output().to_netcdf(filename)
         if self.console:

--- a/pyrcel/model_output.py
+++ b/pyrcel/model_output.py
@@ -57,7 +57,7 @@ class ModelOutput:
     state: np.ndarray
     aerosols: list
     summary: dict
-    V: object
+    V: float | AbstractUpdraft
     T0: float
     S0: float
     P0: float

--- a/pyrcel/parcel_aux.py
+++ b/pyrcel/parcel_aux.py
@@ -27,6 +27,9 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
+from typing import Any  # noqa: E402
 
 from . import constants as c  # noqa: E402
 from .thermo import Seq, dv, es, ka  # noqa: E402
@@ -38,7 +41,7 @@ PI = math.pi
 N_STATE_VARS = c.N_STATE_VARS
 
 
-def parcel_ode_sys(t, y, args):
+def parcel_ode_sys(t: ArrayLike, y: Array, args: Any) -> Array:
     """Instantaneous tendency of the parcel-model state vector.
 
     Parameters

--- a/pyrcel/parcel_aux.py
+++ b/pyrcel/parcel_aux.py
@@ -20,6 +20,7 @@ Equivalence with the numba derivative is verified against frozen fixtures in
 from __future__ import annotations
 
 import math
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -29,7 +30,6 @@ jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp  # noqa: E402
 from jax import Array  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
-from typing import Any  # noqa: E402
 
 from . import constants as c  # noqa: E402
 from .thermo import Seq, dv, es, ka  # noqa: E402

--- a/pyrcel/thermo.py
+++ b/pyrcel/thermo.py
@@ -22,13 +22,15 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
 
 from . import constants as c  # noqa: E402
 
 PI = math.pi
 
 
-def sigma_w(T):
+def sigma_w(T: ArrayLike) -> Array:
     """Surface tension of water for a given temperature.
 
     Parameters
@@ -48,7 +50,7 @@ def sigma_w(T):
     return 0.0761 - 1.55e-4 * (T - 273.15)
 
 
-def dv_cont(T, P):
+def dv_cont(T: ArrayLike, P: ArrayLike) -> Array:
     """Diffusivity of water vapor in air, neglecting non-continuum effects.
 
     Parameters
@@ -71,7 +73,7 @@ def dv_cont(T, P):
     return 1e-4 * (0.211 / P_atm) * ((T / 273.0) ** 1.94)
 
 
-def dv(T, r, P, accom=c.ac):
+def dv(T: ArrayLike, r: ArrayLike, P: ArrayLike, accom: ArrayLike = c.ac) -> Array:
     """Diffusivity of water vapor in air, modified for non-continuum effects.
 
     Parameters
@@ -99,7 +101,7 @@ def dv(T, r, P, accom=c.ac):
     return dv_t / denom
 
 
-def es(T_c):
+def es(T_c: ArrayLike) -> Array:
     """Saturation vapor pressure over water for a given temperature.
 
     Parameters
@@ -119,7 +121,7 @@ def es(T_c):
     return 611.2 * jnp.exp(17.67 * T_c / (T_c + 243.5))
 
 
-def ka_cont(T):
+def ka_cont(T: ArrayLike) -> Array:
     """Thermal conductivity of air, neglecting non-continuum effects.
 
     Parameters
@@ -139,7 +141,7 @@ def ka_cont(T):
     return 1e-3 * (4.39 + 0.071 * T)
 
 
-def ka(T, rho, r):
+def ka(T: ArrayLike, rho: ArrayLike, r: ArrayLike) -> Array:
     """Thermal conductivity of air, modified for non-continuum effects.
 
     Parameters
@@ -165,7 +167,7 @@ def ka(T, rho, r):
     return ka_t / denom
 
 
-def rho_air(T, P, RH=1.0):
+def rho_air(T: ArrayLike, P: ArrayLike, RH: ArrayLike = 1.0) -> Array:
     """Density of moist air for a given temperature, pressure, and relative humidity.
 
     Parameters
@@ -191,7 +193,7 @@ def rho_air(T, P, RH=1.0):
     return P / c.Rd / Tv
 
 
-def Seq(r, r_dry, T, kappa):
+def Seq(r: ArrayLike, r_dry: ArrayLike, T: ArrayLike, kappa: ArrayLike) -> Array:
     """κ-Köhler equilibrium supersaturation over an aerosol particle.
 
     Two numerical stability improvements over the naïve formulation:
@@ -247,7 +249,7 @@ def Seq(r, r_dry, T, kappa):
     return B * jnp.expm1(A) + Bm1
 
 
-def Seq_approx(r, r_dry, T, kappa):
+def Seq_approx(r: ArrayLike, r_dry: ArrayLike, T: ArrayLike, kappa: ArrayLike) -> Array:
     """Approximate κ-Köhler equilibrium supersaturation over an aerosol particle.
 
     Parameters

--- a/pyrcel/updraft.py
+++ b/pyrcel/updraft.py
@@ -23,12 +23,14 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
 
 
 class AbstractUpdraft(eqx.Module):
     """Base class for updraft models. Subclasses implement ``__call__(t) -> V``."""
 
-    def __call__(self, t):  # pragma: no cover - abstract
+    def __call__(self, t: ArrayLike) -> Array:  # pragma: no cover - abstract
         raise NotImplementedError
 
 
@@ -37,11 +39,11 @@ class ConstantV(AbstractUpdraft):
 
     V: jax.Array
 
-    def __init__(self, V):
+    def __init__(self, V: ArrayLike) -> None:
         # Store as a float64 scalar array so it is a differentiable pytree leaf.
         self.V = jnp.asarray(V, dtype=jnp.float64)
 
-    def __call__(self, t):
+    def __call__(self, t: ArrayLike) -> Array:
         return self.V
 
 
@@ -60,11 +62,11 @@ class InterpolatedUpdraft(AbstractUpdraft):
     ts: jax.Array
     vs: jax.Array
 
-    def __init__(self, ts, vs):
+    def __init__(self, ts: ArrayLike, vs: ArrayLike) -> None:
         self.ts = jnp.asarray(ts, dtype=jnp.float64)
         self.vs = jnp.asarray(vs, dtype=jnp.float64)
 
-    def __call__(self, t):
+    def __call__(self, t: ArrayLike) -> Array:
         return jnp.interp(t, self.ts, self.vs)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,7 @@ gpu = [
 ]
 test = [
     { name = "hypothesis" },
+    { name = "pyrefly" },
     { name = "pytest" },
 ]
 
@@ -1148,6 +1149,7 @@ requires-dist = [
     { name = "optimistix", marker = "extra == 'gpu'", specifier = ">=0.0.7" },
     { name = "pandas" },
     { name = "polars" },
+    { name = "pyrefly", marker = "extra == 'test'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7" },
     { name = "pyyaml" },
     { name = "scipy" },
@@ -1155,6 +1157,25 @@ requires-dist = [
     { name = "xarray" },
 ]
 provides-extras = ["gpu", "test", "examples"]
+
+[[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
+]
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
## Summary

- Adds `pyrcel/py.typed` (PEP 561 marker so type checkers know the package ships inline types)
- Annotates all public APIs across the v2 modules with JAX-idiomatic types: `ArrayLike` for inputs, `Array` for JAX-array returns, `NDArray[np.floating[Any]]` for numpy-facing functions (distributions, aerosol, ensemble), and concrete Python types everywhere else
- Configures [pyrefly](https://pyrefly.org) (Meta's new Rust-based type checker) via `[tool.pyrefly]` in `pyproject.toml`, migrated from pyright using `pyrefly init`
- Six error categories suppressed in `[tool.pyrefly.errors]` for known JAX/diffrax/optimistix false positives (untyped imports, ArrayLike arithmetic, dynamic dispatch return types)
- Wires `pyrefly check` into CI (runs after ruff, before tests) and `prek.toml` (pre-commit hook)

## Test plan

- [ ] `uvx pyrefly check` passes with 0 errors (3 suppressed: 2 optimistix stub false positives, 1 `rs = None` in monodisperse aerosol path)
- [ ] `ruff check` and `ruff format --check` pass (import order fixed for stdlib `typing` imports in JAX modules)
- [ ] Fast test suite (`pytest -m "not slow"`) still passes (186 passed)
- [ ] CI runs `pyrefly check` step on every PR going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are annotations, type-checker wiring, and narrow asserts—no runtime behavior changes to the scientific core.
> 
> **Overview**
> Adds **static type checking** with **pyrefly** across CI and pre-commit, plus inline types on the v2 `pyrcel` API so downstream tools can rely on PEP 561 semantics.
> 
> **Tooling:** `pyrefly>=1.1` is a test extra; `[tool.pyrefly]` scopes checks to `pyrcel` (excluding legacy, scripts, `output.py`, etc.) and ignores several JAX/diffrax/optimistix false-positive categories. CI runs `uv run pyrefly check` after ruff; `prek.toml` adds a matching hook.
> 
> **Annotations:** v2 modules gain `ArrayLike` / `Array` on JAX paths, `NDArray` / `_Float` on NumPy distribution and aerosol code, and tighter signatures on `ActivationScheme`, `ParcelModel`, integrator/equilibrate/ensemble entry points. A few **pyrefly ignore** comments cover optimistix `Bisection` stubs and monodisperse `rs = None`. `integrator` adds an `assert sol.ys is not None` in the chunked path; `model.py` narrows output guards with asserts on `time`/`x`/`_summary`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3743cbcd742cd376e0f3ab9dda8caa0cfdc74fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->