### PR TITLE
feat(v2): rewrite run_parcel CLI for v2 ParcelModel (issue #60)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ examples = [
     "matplotlib>=3.5",
 ]
 
+[project.scripts]
+run_parcel = "pyrcel.scripts.run_parcel:run_parcel"
+
 [project.urls]
 Documentation = "https://pyrcel.readthedocs.io/en/latest/"
 Repository = "https://github.com/darothen/pyrcel"

--- a/pyrcel/scripts/run_parcel.py
+++ b/pyrcel/scripts/run_parcel.py
@@ -23,6 +23,7 @@ The namelist is a YAML file with three required top-level keys:
         t_end: 9999.0           # maximum integration time (s)
         terminate: true         # stop shortly after S_max (recommended)
         terminate_depth: 10.0   # extra height (m) to integrate past S_max
+        max_steps: 100000       # optional: adaptive-step cap (default 100 000)
 
     initial_aerosol:
         - name: sulfate
@@ -37,14 +38,26 @@ The namelist is a YAML file with three required top-level keys:
         pressure: 85000.0         # Pa
         updraft_speed: 0.44       # m/s
 
+``model_control`` keys recognised by the v2 CLI:
+
+===================  ======================================================
+Key                  Description
+===================  ======================================================
+``t_end``            Maximum integration time (s). **Required.**
+``output_dt``        Output cadence (s). Default: ``1.0``.
+``terminate``        Stop after S_max. Default: ``true``.
+``terminate_depth``  Extra depth (m) past S_max. Default: ``10.0``.
+``max_steps``        Adaptive-step cap. Default: ``100000``.
+``solver_dt``        **Ignored** (legacy CVode chunk size; diffrax is fully
+                     adaptive and does not need this).
+===================  ======================================================
+
 Notes
 -----
 - Only ``lognormal`` distributions are supported; ``distribution_args`` maps to
   :class:`~pyrcel.distributions.Lognorm` keyword arguments (``mu``, ``sigma``, ``N``).
 - ``relative_humidity`` is converted to initial supersaturation via
   ``S0 = RH - 1.0`` (negative for sub-saturated parcels).
-- ``solver_dt`` from the old namelist is silently ignored; the v2 diffrax backend
-  uses an adaptive step controller.
 - Output is written as NetCDF4 via :meth:`~pyrcel.model_output.ModelOutput.to_netcdf`.
 """
 
@@ -135,6 +148,7 @@ def run_parcel() -> None:
         "output_dt": mc.get("output_dt", 1.0),
         "terminate": mc.get("terminate", True),
         "terminate_depth": mc.get("terminate_depth", 10.0),
+        "max_steps": int(mc.get("max_steps", 100_000)),
     }
     output = model.run(**run_kwargs, mode="full")
 
@@ -143,6 +157,7 @@ def run_parcel() -> None:
         out_path = Path(args.output)
         if out_path.suffix != ".nc":
             out_path = out_path.with_suffix(".nc")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
     else:
         ec = cfg["experiment_control"]
         out_dir = Path(ec.get("output_dir", "output"))

--- a/pyrcel/scripts/run_parcel.py
+++ b/pyrcel/scripts/run_parcel.py
@@ -106,8 +106,7 @@ def run_parcel() -> None:
         dist_key = ap["distribution"]
         if dist_key not in _DIST_MAP:
             print(
-                f"error: unsupported distribution '{dist_key}'. "
-                f"Supported: {list(_DIST_MAP)}",
+                f"error: unsupported distribution '{dist_key}'. Supported: {list(_DIST_MAP)}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/pyrcel/scripts/run_parcel.py
+++ b/pyrcel/scripts/run_parcel.py
@@ -1,0 +1,159 @@
+"""CLI interface for running a parcel-model simulation with the v2 JAX/diffrax backend.
+
+Usage
+-----
+.. code-block:: bash
+
+    run_parcel config.yml                    # write output/<name>.nc
+    run_parcel config.yml -o results/run1   # explicit output path (no .nc extension needed)
+    run_parcel config.yml --no-console      # suppress the setup/summary table
+
+YAML Namelist Format
+--------------------
+The namelist is a YAML file with three required top-level keys:
+
+.. code-block:: yaml
+
+    experiment_control:
+        name: "simple"          # base name for the output file
+        output_dir: "output/"   # directory to write the NetCDF file into
+
+    model_control:
+        output_dt: 1.0          # output cadence (s)
+        t_end: 9999.0           # maximum integration time (s)
+        terminate: true         # stop shortly after S_max (recommended)
+        terminate_depth: 10.0   # extra height (m) to integrate past S_max
+
+    initial_aerosol:
+        - name: sulfate
+          distribution: lognormal
+          distribution_args: { mu: 0.15, N: 1000.0, sigma: 1.2 }
+          kappa: 0.54
+          bins: 250
+
+    initial_conditions:
+        temperature: 283.15       # K
+        relative_humidity: 0.95   # decimal fraction (0–1)
+        pressure: 85000.0         # Pa
+        updraft_speed: 0.44       # m/s
+
+Notes
+-----
+- Only ``lognormal`` distributions are supported; ``distribution_args`` maps to
+  :class:`~pyrcel.distributions.Lognorm` keyword arguments (``mu``, ``sigma``, ``N``).
+- ``relative_humidity`` is converted to initial supersaturation via
+  ``S0 = RH - 1.0`` (negative for sub-saturated parcels).
+- ``solver_dt`` from the old namelist is silently ignored; the v2 diffrax backend
+  uses an adaptive step controller.
+- Output is written as NetCDF4 via :meth:`~pyrcel.model_output.ModelOutput.to_netcdf`.
+"""
+
+from __future__ import annotations
+
+import sys
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from pathlib import Path
+
+import yaml
+
+_DIST_MAP = {
+    "lognormal": "Lognorm",
+}
+
+parser = ArgumentParser(
+    prog="run_parcel",
+    description=__doc__,
+    formatter_class=RawDescriptionHelpFormatter,
+)
+parser.add_argument(
+    "namelist",
+    type=str,
+    metavar="config.yml",
+    help="YAML namelist controlling simulation configuration",
+)
+parser.add_argument(
+    "-o",
+    "--output",
+    type=str,
+    default=None,
+    metavar="PATH",
+    help="Override output path (default: <output_dir>/<name>.nc from namelist)",
+)
+parser.add_argument(
+    "--no-console",
+    action="store_true",
+    default=False,
+    help="Suppress the setup/summary console output",
+)
+
+
+def run_parcel() -> None:
+    args = parser.parse_args()
+
+    # --- load namelist -------------------------------------------------------
+    try:
+        with open(args.namelist, "rb") as f:
+            cfg = yaml.safe_load(f)
+    except OSError as exc:
+        print(f"error: cannot read namelist '{args.namelist}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # --- build aerosol modes -------------------------------------------------
+    import pyrcel as pm
+
+    aerosol_modes = []
+    for ap in cfg["initial_aerosol"]:
+        dist_key = ap["distribution"]
+        if dist_key not in _DIST_MAP:
+            print(
+                f"error: unsupported distribution '{dist_key}'. "
+                f"Supported: {list(_DIST_MAP)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        dist_cls = getattr(pm, _DIST_MAP[dist_key])
+        dist = dist_cls(**ap["distribution_args"])
+        aer = pm.AerosolSpecies(ap["name"], dist, kappa=ap["kappa"], bins=ap["bins"])
+        aerosol_modes.append(aer)
+
+    # --- initialise model ----------------------------------------------------
+    ic = cfg["initial_conditions"]
+    S0 = ic["relative_humidity"] - 1.0  # RH=0.95 → S0=-0.05
+
+    model = pm.ParcelModel(
+        aerosol_modes,
+        V=ic["updraft_speed"],
+        T0=ic["temperature"],
+        S0=S0,
+        P0=ic["pressure"],
+        console=not args.no_console,
+    )
+
+    # --- run -----------------------------------------------------------------
+    mc = cfg["model_control"]
+    run_kwargs = {
+        "t_end": mc["t_end"],
+        "output_dt": mc.get("output_dt", 1.0),
+        "terminate": mc.get("terminate", True),
+        "terminate_depth": mc.get("terminate_depth", 10.0),
+    }
+    output = model.run(**run_kwargs, mode="full")
+
+    # --- write output --------------------------------------------------------
+    if args.output:
+        out_path = Path(args.output)
+        if out_path.suffix != ".nc":
+            out_path = out_path.with_suffix(".nc")
+    else:
+        ec = cfg["experiment_control"]
+        out_dir = Path(ec.get("output_dir", "output"))
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{ec['name']}.nc"
+
+    output.to_netcdf(out_path)
+    if not args.no_console:
+        print(f"Output written to {out_path}")
+
+
+if __name__ == "__main__":
+    run_parcel()

--- a/tests/fixtures/cli_simple.yml
+++ b/tests/fixtures/cli_simple.yml
@@ -1,0 +1,22 @@
+experiment_control:
+    name: "cli_smoke"
+    output_dir: "output/"
+
+model_control:
+    output_dt: 5.0
+    t_end: 200.0
+    terminate: true
+    terminate_depth: 10.0
+
+initial_aerosol:
+    - name: sulfate
+      distribution: lognormal
+      distribution_args: { mu: 0.05, N: 1000.0, sigma: 1.6 }
+      kappa: 0.54
+      bins: 10
+
+initial_conditions:
+    temperature: 283.15
+    relative_humidity: 0.95
+    pressure: 85000.0
+    updraft_speed: 0.5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,83 @@
+"""Smoke tests for the run_parcel CLI (issue #60)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "cli_simple.yml"
+
+
+@pytest.mark.slow
+def test_cli_runs_and_writes_netcdf(tmp_path):
+    """run_parcel with a minimal YAML produces a valid NetCDF file."""
+    out = tmp_path / "smoke.nc"
+    result = subprocess.run(
+        [sys.executable, "-m", "pyrcel.scripts.run_parcel", str(FIXTURE), "-o", str(out),
+         "--no-console"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
+    assert out.exists(), "NetCDF file was not created"
+    assert out.stat().st_size > 0
+
+    import xarray as xr
+
+    ds = xr.open_dataset(out)
+    assert "S" in ds
+    assert "T" in ds
+    assert ds.sizes["time"] > 1
+    ds.close()
+
+
+@pytest.mark.slow
+def test_cli_output_dir_from_namelist(tmp_path):
+    """run_parcel writes to <output_dir>/<name>.nc when -o is omitted."""
+    import tempfile
+
+    import yaml
+
+    cfg = yaml.safe_load(FIXTURE.read_text())
+    cfg["experiment_control"]["output_dir"] = str(tmp_path / "out")
+    cfg["experiment_control"]["name"] = "test_run"
+
+    with tempfile.NamedTemporaryFile(suffix=".yml", mode="w", delete=False) as f:
+        yaml.dump(cfg, f)
+        yml_path = f.name
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pyrcel.scripts.run_parcel", yml_path, "--no-console"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
+        expected = tmp_path / "out" / "test_run.nc"
+        assert expected.exists()
+    finally:
+        Path(yml_path).unlink(missing_ok=True)
+
+
+def test_cli_missing_namelist(tmp_path):
+    """run_parcel exits 1 when the namelist file does not exist."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pyrcel.scripts.run_parcel", str(tmp_path / "nope.yml")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_cli_help():
+    """run_parcel --help exits 0 and mentions the namelist argument."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pyrcel.scripts.run_parcel", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "config.yml" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,8 +16,15 @@ def test_cli_runs_and_writes_netcdf(tmp_path):
     """run_parcel with a minimal YAML produces a valid NetCDF file."""
     out = tmp_path / "smoke.nc"
     result = subprocess.run(
-        [sys.executable, "-m", "pyrcel.scripts.run_parcel", str(FIXTURE), "-o", str(out),
-         "--no-console"],
+        [
+            sys.executable,
+            "-m",
+            "pyrcel.scripts.run_parcel",
+            str(FIXTURE),
+            "-o",
+            str(out),
+            "--no-console",
+        ],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary

- New `pyrcel/scripts/run_parcel.py` backed by `pyrcel.model.ParcelModel` (JAX/diffrax)
- Reads the same YAML namelist format as the old CLI (`experiment_control`, `model_control`, `initial_aerosol`, `initial_conditions`)
- `relative_humidity` → `S0 = RH - 1.0`; `solver_dt` silently ignored (diffrax uses adaptive steps)
- Writes NetCDF output via `ModelOutput.to_netcdf()`; `-o` flag overrides the namelist-specified path
- `--no-console` flag suppresses the setup/summary table (default: on)
- Registers `run_parcel` entry point in `[project.scripts]`

## Test plan

- [ ] `test_cli_missing_namelist` — exit 1 on bad path (fast)
- [ ] `test_cli_help` — `--help` exits 0 (fast)
- [ ] `test_cli_runs_and_writes_netcdf` — full integration run, validates NetCDF variables (slow)
- [ ] `test_cli_output_dir_from_namelist` — namelist-driven output path (slow)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New user-facing CLI and packaging entry point only; no changes to core model physics or solver code.
> 
> **Overview**
> Adds a **`run_parcel`** console entry point that runs the v2 **`ParcelModel`** (JAX/diffrax) from a YAML namelist compatible with the legacy CLI shape (`experiment_control`, `model_control`, `initial_aerosol`, `initial_conditions`).
> 
> The new **`pyrcel/scripts/run_parcel.py`** loads aerosol modes (lognormal only), maps **`relative_humidity`** to **`S0 = RH - 1`**, runs with **`mode="full"`**, and writes NetCDF via **`ModelOutput.to_netcdf`**. **`-o`** overrides the output path; **`--no-console`** silences setup/summary. Legacy **`solver_dt`** is ignored.
> 
> Tests cover help, missing namelist (exit 1), explicit **`-o`** output (slow), and default **`output_dir`/`name`** paths (slow), using **`tests/fixtures/cli_simple.yml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595d7fa71ad302a78aa828877408b3029bcdb361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->