### PR TITLE
chore(v2): tighten CI triggers and resolve ruff per-file-ignores (#48, #49, #51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-      # TODO(#49): feat/** is here only to run CI on PRs targeting
-      # feat/v2-implementation during the v2 development cycle. Remove
-      # once feat/v2-implementation is merged to main.
-      - "feat/**"
   pull_request:
   workflow_dispatch:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,12 @@ select = ["E", "F", "I", "UP", "NPY"]
 
 [tool.ruff.lint.per-file-ignores]
 # --- pyrcel.legacy files ---
-# These are the preserved NumPy/numba reference implementations. Violations here are
-# tracked for future cleanup in #51. Any suppression that survives that audit must be
-# explicitly documented.
+# Preserved NumPy/numba reference implementations; intentionally not modernised so
+# they remain diff-comparable to the published v1 code.
+# UP031/E731: printf-style strings and lambda assignments are idiomatic in the original.
+# F841: intermediate variables aid readability of the physics.
+# E501: long lines mirror the original equations; breaking them obscures the math.
+# F403/F405 (thermo.py only): wildcard import from constants is the original style.
 "pyrcel/legacy/thermo.py" = ["F403", "F405", "UP031", "E731", "E501"]
 "pyrcel/legacy/activation.py" = ["UP031", "E731", "F841", "E501"]
 "pyrcel/legacy/postprocess.py" = ["UP031", "E731", "F841", "E501"]
@@ -96,12 +99,17 @@ select = ["E", "F", "I", "UP", "NPY"]
 # rejects grouped re-export blocks — suppress rather than let it split them per-symbol.
 "pyrcel/__init__.py" = ["F401", "I001"]
 "pyrcel/activation/__init__.py" = ["F401"]
-# --- other legacy/non-JAX package files ---
-"pyrcel/aerosol.py" = ["UP031", "E731", "F841", "E501"]
-"pyrcel/distributions.py" = ["UP031", "E501"]
+# --- distributions.py ---
+# LaTeX math in RST docstrings produces lines that cannot be split without breaking
+# the rendered equations. E501 is the only remaining suppression; UP031 was fixed.
+"pyrcel/distributions.py" = ["E501"]
+# --- v1-era output module (pyrcel/output.py) ---
+# Not part of the v2 public API (superseded by pyrcel/model_output.py); preserved for
+# backward compatibility. UP031/E731/F841/E501: same rationale as pyrcel.legacy above.
 "pyrcel/output.py" = ["UP031", "E731", "F841", "E501"]
+# --- old unit-test suite (pyrcel/test/) ---
+# Pre-v2 tests; not part of the new pytest suite in tests/. Kept for reference only.
 "pyrcel/test/*.py" = ["F403", "F405", "F401", "UP031", "E501"]
-"pyrcel/constants.py" = ["E501"]
 # --- non-package files ---
 # E402: import order is intentional (sys.path setup, warnings filter before imports)
 "docs/conf.py" = ["E402"]

--- a/pyrcel/distributions.py
+++ b/pyrcel/distributions.py
@@ -292,9 +292,9 @@ class MultiModeLognorm(BaseDistribution):
         raise NotImplementedError()
 
     def __repr__(self) -> str:
-        mus_str = "(" + ", ".join("%2.2e" % mu for mu in self.mus) + ")"
-        sigmas_str = "(" + ", ".join("%2.2e" % sigma for sigma in self.sigmas) + ")"
-        Ns_str = "(" + ", ".join("%2.2e" % N for N in self.Ns) + ")"
+        mus_str = "(" + ", ".join(f"{mu:2.2e}" for mu in self.mus) + ")"
+        sigmas_str = "(" + ", ".join(f"{sigma:2.2e}" for sigma in self.sigmas) + ")"
+        Ns_str = "(" + ", ".join(f"{N:2.2e}" for N in self.Ns) + ")"
         return f"MultiModeLognorm| mus = {mus_str}, sigmas = {sigmas_str}, Totals = {Ns_str} |"
 
 


### PR DESCRIPTION
## Summary

- **#48 / #49** — Remove `feat/**` from `on.push.branches` in CI; CI now fires only on `master`/`main` and `pull_request`, the standard pattern post-v2 merge
- **#51** — Ruff per-file-ignores audit:
  - Drop entries for `pyrcel/aerosol.py` and `pyrcel/constants.py` (both already clean under the project's 100-char line length)
  - Fix `UP031` (printf → f-string) in `MultiModeLognorm.__repr__`; retain `E501`-only entry for `pyrcel/distributions.py` because the LaTeX math in RST docstrings cannot be line-wrapped without breaking the rendered equations
  - Replace the placeholder "tracked for future cleanup in #51" comment on legacy files with explicit, permanent rationale for each surviving suppression
  - Add rationale comments for `pyrcel/output.py` (v1-era module, superseded by `model_output.py`) and `pyrcel/test/` (pre-v2 suite, kept for reference)

## Test plan

- [ ] `ruff format --check` and `ruff check pyrcel/ tests/` pass (verified locally)
- [ ] Fast test suite: 188 passed (verified locally)
- [ ] CI green on PR

Closes #48, #49, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and lint-config/documentation changes plus a cosmetic repr update; no runtime API or physics logic changes.
> 
> **Overview**
> **CI** no longer runs on pushes to `feat/**` branches—only `master`/`main`, pull requests, and manual dispatch—dropping the temporary v2 integration trigger.
> 
> **Ruff configuration** drops per-file ignores for `pyrcel/aerosol.py` and `pyrcel/constants.py` (they pass under current rules), narrows `pyrcel/distributions.py` to **E501** only, and replaces the old “tracked in #51” notes with permanent rationale for legacy, shim, `output.py`, and `pyrcel/test/` suppressions.
> 
> **Code:** `MultiModeLognorm.__repr__` in `distributions.py` uses f-strings instead of printf-style formatting (fixes **UP031**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4797f75b8b2898d561d7eb6e89a7e2803e8ba3e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->