### PR TITLE
feat(v2): JAX-native MBN2014 activation parameterization (issue #56)

### DIFF
--- a/pyrcel/__init__.py
+++ b/pyrcel/__init__.py
@@ -12,7 +12,8 @@ The stable v2 entry points are:
 * :class:`~pyrcel.model_output.ModelOutput` — structured output returned by
   ``ParcelModel.run(mode='full')``; exposes ``.to_pandas()``, ``.to_polars()``,
   ``.to_xarray()``, ``.to_netcdf()``, ``.to_csv()``, ``.to_parquet()``
-* :class:`~pyrcel.activation.ARG2000`, :class:`~pyrcel.activation.ActivationScheme`
+* :class:`~pyrcel.activation.ARG2000`, :class:`~pyrcel.activation.MBN2014`,
+  :class:`~pyrcel.activation.ActivationScheme`
 * :func:`~pyrcel.ensemble.run_updraft_ensemble`,
   :func:`~pyrcel.ensemble.smax_nact_ensemble`
 
@@ -43,6 +44,7 @@ _LAZY_ATTRS = {
     "ParcelModelJAX": "pyrcel.model",
     # activation (JAX-heavy; imported lazily)
     "ARG2000": "pyrcel.activation",
+    "MBN2014": "pyrcel.activation",
     "ActivationScheme": "pyrcel.activation",
     # ensemble utilities
     "run_updraft_ensemble": "pyrcel.ensemble",

--- a/pyrcel/activation/__init__.py
+++ b/pyrcel/activation/__init__.py
@@ -11,6 +11,10 @@ JAX-native
     Abdul-Razzak & Ghan (2000) — closed-form, fully differentiable.
 :class:`ARG2000`
     Callable class wrapper around :func:`arg2000`.
+:func:`mbn2014`
+    Morales Betancourt & Nenes (2014) — bisection + IFT gradient.
+:class:`MBN2014`
+    Callable class wrapper around :func:`mbn2014`.
 :class:`ActivationScheme`
     Abstract base class for all activation schemes.
 
@@ -18,18 +22,18 @@ Legacy (NumPy/SciPy)
 --------------------
 The following names are re-exported from :mod:`pyrcel.legacy.activation`
 so that code importing from ``pyrcel.activation`` continues to work.
-``mbn2014``, ``binned_activation``, ``lognormal_activation``,
-``multi_mode_activation``, ``ming2006``, ``shipwayabel2010``.
+``binned_activation``, ``lognormal_activation``, ``multi_mode_activation``,
+``ming2006``, ``shipwayabel2010``.
 """
 
 # Legacy re-exports — keep the original names accessible.
 from ..legacy.activation import (  # noqa: F401
     binned_activation,
     lognormal_activation,
-    mbn2014,
     ming2006,
     multi_mode_activation,
     shipwayabel2010,
 )
 from ._arg2000 import ARG2000, arg2000  # noqa: F401
+from ._mbn2014 import MBN2014, mbn2014  # noqa: F401
 from ._scheme import ActivationScheme  # noqa: F401

--- a/pyrcel/activation/_arg2000.py
+++ b/pyrcel/activation/_arg2000.py
@@ -19,11 +19,11 @@ jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp  # noqa: E402
 from jax import Array  # noqa: E402
-from jax.scipy.special import erfc  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
 
 from .. import constants as c  # noqa: E402
 from ..thermo import dv, dv_cont, es, ka_cont, sigma_w  # noqa: E402
+from ._common import _lognormal_act  # noqa: E402, F401
 
 
 def _kohler_crit_approx(T: ArrayLike, r_dry: ArrayLike, kappa: ArrayLike) -> tuple[Array, Array]:
@@ -40,34 +40,6 @@ def _kohler_crit_approx(T: ArrayLike, r_dry: ArrayLike, kappa: ArrayLike) -> tup
     r_crit = jnp.sqrt((3.0 * kappa * r_dry**3) / A)
     s_crit = jnp.sqrt((4.0 * A**3) / (27.0 * kappa * r_dry**3))
     return r_crit, s_crit
-
-
-def _lognormal_act(
-    smax: ArrayLike, sigma: ArrayLike, N: ArrayLike, sgi: ArrayLike
-) -> tuple[Array, Array]:
-    """Activated fraction of one lognormal mode.
-
-    Parameters
-    ----------
-    smax : float
-        Maximum parcel supersaturation (decimal).
-    sigma : float
-        Geometric standard deviation.
-    N : float
-        Total number concentration (any unit; returned N_act is in the same unit).
-    sgi : float
-        Modal critical supersaturation (decimal).
-
-    Returns
-    -------
-    N_act : float
-        Activated number concentration.
-    act_frac : float
-        Activated fraction (0–1).
-    """
-    ui = 2.0 * jnp.log(sgi / smax) / (3.0 * jnp.sqrt(2.0) * jnp.log(sigma))
-    N_act = 0.5 * N * erfc(ui)
-    return N_act, N_act / N
 
 
 def arg2000(

--- a/pyrcel/activation/_common.py
+++ b/pyrcel/activation/_common.py
@@ -1,0 +1,40 @@
+"""Shared utility functions for JAX-native activation parameterizations."""
+
+from __future__ import annotations
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.scipy.special import erfc  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
+
+
+def _lognormal_act(
+    smax: ArrayLike, sigma: ArrayLike, N: ArrayLike, sgi: ArrayLike
+) -> tuple[Array, Array]:
+    """Activated fraction of one lognormal mode.
+
+    Parameters
+    ----------
+    smax : float
+        Maximum parcel supersaturation (decimal).
+    sigma : float
+        Geometric standard deviation.
+    N : float
+        Total number concentration (any unit; returned N_act is in the same unit).
+    sgi : float
+        Modal critical supersaturation (decimal).
+
+    Returns
+    -------
+    N_act : float
+        Activated number concentration.
+    act_frac : float
+        Activated fraction (0–1).
+    """
+    ui = 2.0 * jnp.log(sgi / smax) / (3.0 * jnp.sqrt(2.0) * jnp.log(sigma))
+    N_act = 0.5 * N * erfc(ui)
+    return N_act, N_act / N

--- a/pyrcel/activation/_mbn2014.py
+++ b/pyrcel/activation/_mbn2014.py
@@ -1,0 +1,495 @@
+"""JAX-native Morales Betancourt & Nenes (2014) activation parameterization.
+
+The scheme finds the maximum parcel supersaturation by solving the implicit
+equation F(smax, θ) = 0 via bisection, then computes per-mode activated
+fractions from lognormal statistics.  The bisection uses
+:func:`jax.lax.while_loop` so it is JIT-compilable but not differentiable
+through the loop itself.  Differentiability w.r.t. the physical inputs is
+recovered by the **implicit function theorem** (IFT), implemented via
+:func:`jax.custom_vjp`:
+
+    ∂smax/∂θ  =  −(∂F/∂θ) / (∂F/∂smax)   at  F(smax, θ) = 0
+
+Both partial derivatives are evaluated by applying :func:`jax.grad` to the
+residual :func:`_mbn_residual`, which is a plain differentiable JAX function
+(no while_loop).
+
+References
+----------
+.. [MBN2014] Morales Betancourt, R. and Nenes, A.: Droplet activation
+   parameterization: the population splitting concept revisited,
+   Geosci. Model Dev. Discuss., 7, 2903–2932,
+   doi:10.5194/gmdd-7-2903-2014, 2014.
+"""
+
+from __future__ import annotations
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402
+from jax import Array  # noqa: E402
+from jax.typing import ArrayLike  # noqa: E402
+
+from .. import constants as c  # noqa: E402
+from ..thermo import ka_cont  # noqa: E402
+from ._arg2000 import _lognormal_act  # noqa: E402
+
+# Bisection search bounds and convergence settings (match legacy defaults).
+_XMIN: float = 1e-5
+_XMAX: float = 0.5
+_TOL: float = 1e-6
+_MAX_ITERS: int = 200
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _vpres_jax(T: ArrayLike) -> Array:
+    """Saturated water vapour pressure (mb) — polynomial fit.
+
+    Uses the same coefficients and reference temperature (273 K, not 273.15 K)
+    as :func:`pyrcel.legacy.activation._vpres` to preserve numerical agreement
+    with the legacy implementation.
+    """
+    A = jnp.array(
+        [
+            6.107799610e0,
+            4.436518521e-1,
+            1.428945805e-2,
+            2.650648471e-4,
+            3.031240396e-6,
+            2.034080948e-8,
+            6.136820929e-11,
+        ]
+    )
+    Tc = T - 273.0  # legacy uses 273, not 273.15
+    vp = A[6]
+    for ai in [A[5], A[4], A[3], A[2], A[1]]:
+        vp = vp * Tc + ai
+    return vp * Tc + A[0]
+
+
+def _erfp_jax(x: ArrayLike) -> Array:
+    """Polynomial erf approximation — JAX-traceable analogue of legacy _erfp.
+
+    Used *only* inside the MBN2014 condensation integrals to match the
+    published scheme exactly.  The final lognormal activation step uses
+    :func:`jax.scipy.special.erfc` (accurate).
+    """
+    AA = jnp.array([0.278393, 0.230389, 0.000972, 0.078108])
+    y = jnp.abs(x)
+    axx = 1.0 + y * (AA[0] + y * (AA[1] + y * (AA[2] + y * AA[3])))
+    axx = axx**4
+    axx = 1.0 - 1.0 / axx
+    return jnp.where(x <= 0.0, -axx, axx)
+
+
+def _sintegral_jax(
+    smax: Array,
+    sgis: Array,
+    Ns_m: Array,
+    sigmas: Array,
+    A: Array,
+    beta2: Array,
+    alpha: Array,
+    V: Array,
+) -> tuple[Array, Array]:
+    """Vectorised condensation integrals I₁ and I₂ from MBN2014 (App. B).
+
+    Parameters
+    ----------
+    smax : float
+        Trial maximum supersaturation (decimal).
+    sgis : array, shape (n,)
+        Modal critical supersaturations (decimal).
+    Ns_m : array, shape (n,)
+        Modal number concentrations (m⁻³).
+    sigmas : array, shape (n,)
+        Geometric standard deviations.
+    A : float
+        Köhler surface-tension coefficient (m).
+    beta2 : float
+        Inverse condensational growth coefficient (s/m²).
+    alpha : float
+        Thermodynamic alpha coefficient (1/m).
+    V : float
+        Updraft speed (m/s).
+
+    Returns
+    -------
+    I1, I2 : float
+        Summed condensation integrals (SI units).
+    """
+    sqrtwo = jnp.sqrt(2.0)
+    log_sigmas = jnp.log(sigmas)
+    d_eq = A * 2.0 / sgis / 3.0 / jnp.sqrt(3.0)
+
+    # --- population-splitting supersaturation ssplt2 (and ssplt1) -----------
+    zeta_c = ((16.0 / 9.0) * alpha * V * beta2 * A**2) ** 0.25
+    delta = 1.0 - (zeta_c / smax) ** 4.0
+    critical = delta <= 0.0
+
+    # Critical branch: ratio formula from MBN2014 eq. (B12)
+    ratio_c = (1.0 / sqrtwo) + (2e7 / 3.0) * A * (smax**-0.3824 - zeta_c**-0.3824)
+    ssplt2_c = smax * jnp.minimum(ratio_c, 1.0)
+
+    # Non-critical branch: roots of the quartic, eq. (B10)
+    safe_delta = jnp.maximum(delta, 0.0)
+    sqrt_delta = jnp.sqrt(safe_delta)
+    ssplt2_nc = jnp.sqrt(0.5 * (1.0 + sqrt_delta)) * smax
+    # ssplt1 could be 0 when delta → 0; guard the log below
+    safe_ssplt1_sq = jnp.maximum(0.5 * (1.0 - sqrt_delta), 0.0)
+    ssplt1_nc = jnp.sqrt(safe_ssplt1_sq) * smax
+
+    ssplt2 = jnp.where(critical, ssplt2_c, ssplt2_nc)
+    ssplt1 = ssplt1_nc  # guarded; only selected in non-critical branch
+
+    # --- integ2: same formula in both branches (eq. B5) ---------------------
+    log_sgi_sp2 = jnp.log(sgis / ssplt2)
+    log_sgi_smax = jnp.log(sgis / smax)
+    log_factor = 3.0 * log_sigmas / (2.0 * sqrtwo)
+    u_sp2 = 2.0 * log_sgi_sp2 / (3.0 * sqrtwo * log_sigmas)
+    u_smax = 2.0 * log_sgi_smax / (3.0 * sqrtwo * log_sigmas)
+    exp98 = jnp.exp(9.0 / 8.0 * log_sigmas**2)
+    integ2 = (exp98 * Ns_m / sgis) * (
+        _erfp_jax(u_sp2 - log_factor) - _erfp_jax(u_smax - log_factor)
+    )
+
+    # --- integ1 + I_extra: differs between branches --------------------------
+    # Both branches are evaluated (jnp.where); guarded quantities avoid NaN.
+
+    # Critical branch (eq. B13)
+    u_sp_plus_c = sqrtwo * log_sgi_sp2 / 3.0 / log_sigmas
+    I_extra_c = (
+        Ns_m
+        * d_eq
+        * exp98
+        * (1.0 - _erfp_jax(u_sp_plus_c - log_factor))
+        * jnp.sqrt(beta2 * alpha * V)
+    )
+    integ1_c = jnp.zeros_like(Ns_m)
+
+    # Non-critical branch (eqs. B3–B4, B6)
+    g_i = jnp.exp(4.5 * log_sigmas**2)
+    sg_ratio_sq = (sgis / smax) ** 2
+    safe_ssplt1 = jnp.maximum(ssplt1, 1e-30 * smax)
+    log_sgi_sp1 = jnp.log(sgis / safe_ssplt1)
+    u_sp1 = 2.0 * log_sgi_sp1 / (3.0 * sqrtwo * log_sigmas)
+    shift = 3.0 * log_sigmas / sqrtwo
+
+    def _i1_part(u_sp: Array) -> Array:
+        return (
+            Ns_m
+            * smax
+            * ((1.0 - _erfp_jax(u_sp)) - 0.5 * sg_ratio_sq * g_i * (1.0 - _erfp_jax(u_sp + shift)))
+        )
+
+    integ1_nc = _i1_part(u_sp2) - _i1_part(u_sp1)
+    u_sp1_inertial = sqrtwo * log_sgi_sp1 / 3.0 / log_sigmas
+    I_extra_nc = (
+        Ns_m
+        * d_eq
+        * exp98
+        * (1.0 - _erfp_jax(u_sp1_inertial - log_factor))
+        * jnp.sqrt(beta2 * alpha * V)
+    )
+
+    integ1 = jnp.where(critical, integ1_c, integ1_nc)
+    I_extra = jnp.where(critical, I_extra_c, I_extra_nc)
+
+    return jnp.sum(integ1 + I_extra), jnp.sum(integ2)
+
+
+def _mbn_residual(
+    smax: Array,
+    V: Array,
+    T: Array,
+    P: Array,
+    mus_m: Array,
+    sigmas: Array,
+    Ns_m: Array,
+    kappas: Array,
+    accom: Array,
+) -> Array:
+    """Implicit equation F(smax, θ) = 0 whose root defines smax.
+
+    All operations are standard JAX, making this fully differentiable w.r.t.
+    every argument (used by the IFT backward pass).
+
+    Parameters
+    ----------
+    smax : float
+        Candidate supersaturation.
+    V, T, P : float
+        Updraft speed (m/s), temperature (K), pressure (Pa).
+    mus_m : array, shape (n,)
+        Median dry *radii* in **metres** (not μm; conversion done by caller).
+    sigmas : array, shape (n,)
+        Geometric standard deviations.
+    Ns_m : array, shape (n,)
+        Number concentrations in **m⁻³**.
+    kappas : array, shape (n,)
+        Hygroscopicity parameters.
+    accom : float
+        Condensation accommodation coefficient.
+
+    Returns
+    -------
+    float
+        Residual F(smax, θ).  Zero at the physical solution.
+    """
+    rho_a = P * c.Ma / c.R / T
+
+    # Surface tension (273 K reference to match legacy implementation exactly)
+    surt = 0.0761 - 1.55e-4 * (T - 273.0)
+    A = 4.0 * c.Mw * surt / c.R / T / c.rho_w
+
+    # Critical supersaturation per mode (Köhler approximation, eq. 5 of MBN2014)
+    dpgs = 2.0 * mus_m  # diameter in m
+    sgis = jnp.exp(jnp.sqrt(4.0 * A**3 / 27.0 / kappas / dpgs**3)) - 1.0
+
+    # Saturated vapour pressure (mb → Pa)
+    wv_pres_sat = _vpres_jax(T) * (1e5 / 1e3)
+
+    # Thermodynamic alpha / beta1 (same as parcel ODE alpha / gamma_p)
+    alpha = c.g * c.Mw * c.L / c.Cp / c.R / T**2 - c.g * c.Ma / c.R / T
+    beta1 = P * c.Ma / wv_pres_sat / c.Mw + c.Mw * c.L**2 / c.Cp / c.R / T**2
+
+    # Nenes diffusivity correction (continuum form matched to legacy)
+    dv_orig = 1e-4 * (0.211 / (P / 1.013e5) * (T / 273.0) ** 1.94)
+    dv_big = 5.0e-6
+    dv_low = 1e-6 * 0.207683 * accom**-0.33048
+    coef = jnp.sqrt(2.0 * jnp.pi * c.Mw / (c.R * T))
+    dv_lam = 2.0 * dv_orig / accom * coef  # mean-free-path correction length
+    dv_ave = (dv_orig / (dv_big - dv_low)) * (
+        (dv_big - dv_low) - dv_lam * jnp.log((dv_big + dv_lam) / (dv_low + dv_lam))
+    )
+
+    # beta2 = 1/G (inverse condensational growth coefficient)
+    beta2 = c.R * T * c.rho_w / wv_pres_sat / dv_ave / c.Mw / 4.0 + (
+        c.L * c.rho_w / 4.0 / ka_cont(T) / T * (c.L * c.Mw / c.R / T - 1.0)
+    )
+
+    beta = 0.5 * jnp.pi * beta1 * c.rho_w / beta2 / alpha / V / rho_a
+    cf1 = 0.5 * jnp.sqrt(1.0 / beta2 / (alpha * V))
+    cf2 = A / 3.0
+
+    I1, I2 = _sintegral_jax(smax, sgis, Ns_m, sigmas, A, beta2, alpha, V)
+    return (I1 * cf1 + I2 * cf2) * beta * smax - 1.0
+
+
+# ---------------------------------------------------------------------------
+# while_loop bisection — JIT-compilable but not differentiable through loop
+# ---------------------------------------------------------------------------
+
+
+def _bisect(F, x_lo: Array, x_hi: Array) -> Array:
+    """Bisect F on [x_lo, x_hi] using jax.lax.while_loop."""
+    y_lo = F(x_lo)
+    y_hi = F(x_hi)  # noqa: F841  # evaluated to establish bracket validity
+
+    def cond(carry):
+        x1, _, x2, _, it = carry
+        return (jnp.abs(x2 - x1) > _TOL * jnp.abs(x1)) & (it < _MAX_ITERS)
+
+    def body(carry):
+        x1, y1, x2, y2, it = carry
+        xm = 0.5 * (x1 + x2)
+        ym = F(xm)
+        same_sign = (y1 * ym) > 0.0
+        return (
+            jnp.where(same_sign, xm, x1),
+            jnp.where(same_sign, ym, y1),
+            jnp.where(same_sign, x2, xm),
+            jnp.where(same_sign, y2, ym),
+            it + 1,
+        )
+
+    x1, _, x2, _, _ = jax.lax.while_loop(cond, body, (x_lo, y_lo, x_hi, y_hi, 0))
+    return 0.5 * (x1 + x2)
+
+
+# ---------------------------------------------------------------------------
+# custom_vjp wrapper — IFT gradient over the bisection
+# ---------------------------------------------------------------------------
+
+
+@jax.custom_vjp
+def _smax_bisect(
+    V: Array,
+    T: Array,
+    P: Array,
+    mus_m: Array,
+    sigmas: Array,
+    Ns_m: Array,
+    kappas: Array,
+    accom: Array,
+) -> Array:
+    """Find smax via while_loop bisection (forward only; IFT provides the VJP)."""
+
+    def F(s: Array) -> Array:
+        return _mbn_residual(s, V, T, P, mus_m, sigmas, Ns_m, kappas, accom)
+
+    return _bisect(F, jnp.asarray(_XMIN), jnp.asarray(_XMAX))
+
+
+def _smax_bisect_fwd(
+    V: Array,
+    T: Array,
+    P: Array,
+    mus_m: Array,
+    sigmas: Array,
+    Ns_m: Array,
+    kappas: Array,
+    accom: Array,
+) -> tuple[Array, tuple]:
+    smax = _smax_bisect(V, T, P, mus_m, sigmas, Ns_m, kappas, accom)
+    return smax, (smax, V, T, P, mus_m, sigmas, Ns_m, kappas, accom)
+
+
+def _smax_bisect_bwd(res: tuple, g: Array) -> tuple:
+    smax, V, T, P, mus_m, sigmas, Ns_m, kappas, accom = res
+    # Evaluate ∂F/∂smax and ∂F/∂θ at the solution via automatic differentiation
+    # of the differentiable residual (no while_loop involved here).
+    all_grads = jax.grad(_mbn_residual, argnums=range(9))(
+        smax, V, T, P, mus_m, sigmas, Ns_m, kappas, accom
+    )
+    dF_dsmax = all_grads[0]
+    # IFT: ∂smax/∂θᵢ = −(∂F/∂θᵢ) / (∂F/∂smax)
+    scale = -g / dF_dsmax
+    return tuple(
+        scale * gi for gi in all_grads[1:]
+    )  # (dV, dT, dP, dmus, dsigmas, dNs, dkappas, daccom)
+
+
+_smax_bisect.defvjp(_smax_bisect_fwd, _smax_bisect_bwd)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def mbn2014(
+    V: ArrayLike,
+    T: ArrayLike,
+    P: ArrayLike,
+    mus: ArrayLike,
+    sigmas: ArrayLike,
+    Ns: ArrayLike,
+    kappas: ArrayLike,
+    accom: float = c.ac,
+) -> tuple[Array, Array, Array]:
+    """JAX-native Morales Betancourt & Nenes (2014) activation parameterization.
+
+    A faithful JAX re-implementation of :func:`pyrcel.legacy.activation.mbn2014`.
+    The maximum parcel supersaturation is found by bisecting the implicit
+    equation derived in [MBN2014]_ using :func:`jax.lax.while_loop`.
+    Gradients w.r.t. all physical inputs are available via :func:`jax.grad`
+    through the **implicit function theorem** (IFT).
+
+    Parameters
+    ----------
+    V : float
+        Updraft speed (m/s).
+    T : float
+        Parcel temperature (K).
+    P : float
+        Parcel pressure (Pa).
+    mus : array-like, shape (n_modes,)
+        Median dry radii of each lognormal mode (μm).
+    sigmas : array-like, shape (n_modes,)
+        Geometric standard deviations (> 1).
+    Ns : array-like, shape (n_modes,)
+        Total number concentrations (cm⁻³).
+    kappas : array-like, shape (n_modes,)
+        Hygroscopicity parameters.
+    accom : float, optional
+        Condensation accommodation coefficient (default :data:`pyrcel.constants.ac`).
+
+    Returns
+    -------
+    smax : float
+        Maximum parcel supersaturation (decimal).
+    N_acts : jnp.ndarray, shape (n_modes,)
+        Activated number concentration per mode (cm⁻³).
+    act_fracs : jnp.ndarray, shape (n_modes,)
+        Activated number fraction per mode.
+
+    References
+    ----------
+    .. [MBN2014] Morales Betancourt, R. and Nenes, A.: Droplet activation
+       parameterization: the population splitting concept revisited,
+       Geosci. Model Dev. Discuss., 7, 2903–2932,
+       doi:10.5194/gmdd-7-2903-2014, 2014.
+
+    See Also
+    --------
+    pyrcel.legacy.activation.mbn2014 : NumPy reference implementation.
+    """
+    mus = jnp.asarray(mus, dtype=float)
+    sigmas = jnp.asarray(sigmas, dtype=float)
+    Ns = jnp.asarray(Ns, dtype=float)
+    kappas = jnp.asarray(kappas, dtype=float)
+    V = jnp.asarray(V, dtype=float)
+    T = jnp.asarray(T, dtype=float)
+    P = jnp.asarray(P, dtype=float)
+    accom = jnp.asarray(accom, dtype=float)
+
+    mus_m = mus * 1e-6  # μm → m
+    Ns_m = Ns * 1e6  # cm⁻³ → m⁻³
+
+    smax = _smax_bisect(V, T, P, mus_m, sigmas, Ns_m, kappas, accom)
+
+    # Recompute sgis at converged smax for the lognormal activation step
+    surt = 0.0761 - 1.55e-4 * (T - 273.0)
+    A = 4.0 * c.Mw * surt / c.R / T / c.rho_w
+    dpgs = 2.0 * mus_m
+    sgis = jnp.exp(jnp.sqrt(4.0 * A**3 / 27.0 / kappas / dpgs**3)) - 1.0
+
+    N_acts_list = []
+    act_fracs_list = []
+    for i in range(len(mus)):
+        N_act, act_frac = _lognormal_act(smax, sigmas[i], Ns[i], sgis[i])
+        N_acts_list.append(N_act)
+        act_fracs_list.append(act_frac)
+
+    return smax, jnp.stack(N_acts_list), jnp.stack(act_fracs_list)
+
+
+class MBN2014:
+    """Morales Betancourt & Nenes (2014) activation scheme.
+
+    A thin callable wrapper around :func:`mbn2014` satisfying the
+    :class:`~pyrcel.activation.ActivationScheme` interface.
+
+    Parameters
+    ----------
+    accom : float, optional
+        Condensation accommodation coefficient forwarded to every call.
+    """
+
+    def __init__(self, accom: float = c.ac) -> None:
+        self.accom = accom
+
+    def __call__(
+        self,
+        V: ArrayLike,
+        T: ArrayLike,
+        P: ArrayLike,
+        mus: ArrayLike,
+        sigmas: ArrayLike,
+        Ns: ArrayLike,
+        kappas: ArrayLike,
+        accom: float | None = None,
+    ) -> tuple[Array, Array, Array]:
+        return mbn2014(
+            V, T, P, mus, sigmas, Ns, kappas, accom=self.accom if accom is None else accom
+        )
+
+    def __repr__(self) -> str:
+        return f"MBN2014(accom={self.accom})"

--- a/pyrcel/activation/_mbn2014.py
+++ b/pyrcel/activation/_mbn2014.py
@@ -1,14 +1,18 @@
 """JAX-native Morales Betancourt & Nenes (2014) activation parameterization.
 
 The scheme finds the maximum parcel supersaturation by solving the implicit
-equation F(smax, θ) = 0 via bisection, then computes per-mode activated
-fractions from lognormal statistics.  The bisection uses
+equation :math:`F(s_\\text{max}, \\theta) = 0` via bisection, then computes
+per-mode activated fractions from lognormal statistics.  The bisection uses
 :func:`jax.lax.while_loop` so it is JIT-compilable but not differentiable
-through the loop itself.  Differentiability w.r.t. the physical inputs is
-recovered by the **implicit function theorem** (IFT), implemented via
+through the loop itself.  Differentiability with respect to the physical inputs
+is recovered by the **implicit function theorem** (IFT), implemented via
 :func:`jax.custom_vjp`:
 
-    ∂smax/∂θ  =  −(∂F/∂θ) / (∂F/∂smax)   at  F(smax, θ) = 0
+.. math::
+
+    \\frac{\\partial s_\\text{max}}{\\partial \\theta}
+    = -\\frac{\\partial F / \\partial \\theta}{\\partial F / \\partial s_\\text{max}}
+    \\quad \\text{at } F(s_\\text{max},\\, \\theta) = 0
 
 Both partial derivatives are evaluated by applying :func:`jax.grad` to the
 residual :func:`_mbn_residual`, which is a plain differentiable JAX function
@@ -34,7 +38,7 @@ from jax.typing import ArrayLike  # noqa: E402
 
 from .. import constants as c  # noqa: E402
 from ..thermo import ka_cont  # noqa: E402
-from ._arg2000 import _lognormal_act  # noqa: E402
+from ._common import _lognormal_act  # noqa: E402
 
 # Bisection search bounds and convergence settings (match legacy defaults).
 _XMIN: float = 1e-5
@@ -217,7 +221,7 @@ def _mbn_residual(
 ) -> Array:
     """Implicit equation F(smax, θ) = 0 whose root defines smax.
 
-    All operations are standard JAX, making this fully differentiable w.r.t.
+    All operations are standard JAX, making this fully differentiable with respect to
     every argument (used by the IFT backward pass).
 
     Parameters
@@ -389,7 +393,7 @@ def mbn2014(
     A faithful JAX re-implementation of :func:`pyrcel.legacy.activation.mbn2014`.
     The maximum parcel supersaturation is found by bisecting the implicit
     equation derived in [MBN2014]_ using :func:`jax.lax.while_loop`.
-    Gradients w.r.t. all physical inputs are available via :func:`jax.grad`
+    Gradients with respect to all physical inputs are available via :func:`jax.grad`
     through the **implicit function theorem** (IFT).
 
     Parameters

--- a/pyrcel/activation/_mbn2014.py
+++ b/pyrcel/activation/_mbn2014.py
@@ -438,7 +438,7 @@ def mbn2014(
     V = jnp.asarray(V, dtype=float)
     T = jnp.asarray(T, dtype=float)
     P = jnp.asarray(P, dtype=float)
-    accom = jnp.asarray(accom, dtype=float)
+    accom = jnp.asarray(accom, dtype=float)  # pyrefly: ignore[bad-assignment]
 
     mus_m = mus * 1e-6  # μm → m
     Ns_m = Ns * 1e6  # cm⁻³ → m⁻³

--- a/tests/test_mbn2014.py
+++ b/tests/test_mbn2014.py
@@ -1,0 +1,226 @@
+"""Tests for the JAX-native MBN2014 activation parameterization (issue #56).
+
+Three layers:
+1. **Cross-check** — JAX :func:`mbn2014` vs legacy NumPy :func:`mbn2014` over
+   a grid of scenarios; smax agreement within 1e-5 relative (bisection uses
+   the same tolerance on both sides but floating-point order differs slightly).
+2. **Gradient check** — :func:`jax.grad` of ``smax`` w.r.t. V, T, P, Ns, kappas
+   agrees with central finite differences to ~1e-2 relative (IFT gradient at
+   a converged root; FD is limited by bisection tolerance, not precision).
+3. **Physical invariants** — smax increases with V; activated fraction is in [0, 1].
+4. **Class interface** — :class:`MBN2014` delegates correctly.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from pyrcel.activation._mbn2014 import mbn2014 as mbn2014_jax  # noqa: E402
+from pyrcel.legacy.activation import mbn2014 as mbn2014_legacy  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared scenarios
+# ---------------------------------------------------------------------------
+
+SINGLE = dict(mus=[0.05], sigmas=[2.0], Ns=[300.0], kappas=[0.6])
+TWO_MODE = dict(mus=[0.02, 0.1], sigmas=[1.5, 2.0], Ns=[500.0, 200.0], kappas=[0.6, 0.2])
+MARINE = dict(
+    mus=[0.07 / 2.0, 0.62 / 2.0],
+    sigmas=[2.0, 2.7],
+    Ns=[60.0, 3.1],
+    kappas=[1.12, 1.12],
+)
+
+UPDRAFT_CONDITIONS = [
+    (0.25, 283.15, 90000.0),
+    (0.50, 283.15, 85000.0),
+    (1.00, 280.00, 80000.0),
+    (2.00, 275.00, 75000.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# 1. Cross-check: JAX vs legacy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("aerosol", [SINGLE, TWO_MODE, MARINE])
+@pytest.mark.parametrize("V,T,P", UPDRAFT_CONDITIONS)
+def test_mbn2014_smax_vs_legacy(aerosol, V, T, P):
+    """JAX and legacy mbn2014 return the same smax to within 1e-5 relative."""
+    smax_jax, _, _ = mbn2014_jax(V, T, P, **aerosol)
+    smax_leg, _, _ = mbn2014_legacy(V, T, P, **aerosol)
+    assert float(smax_jax) == pytest.approx(float(smax_leg), rel=1e-5)
+
+
+@pytest.mark.parametrize("aerosol", [SINGLE, TWO_MODE])
+@pytest.mark.parametrize("V,T,P", [(0.5, 283.15, 85000.0)])
+def test_mbn2014_act_fracs_vs_legacy(aerosol, V, T, P):
+    """Activated fractions agree within 1e-4 relative."""
+    _, _, fracs_jax = mbn2014_jax(V, T, P, **aerosol)
+    _, _, fracs_leg = mbn2014_legacy(V, T, P, **aerosol)
+    np.testing.assert_allclose(np.asarray(fracs_jax), np.asarray(fracs_leg), rtol=1e-4)
+
+
+def test_mbn2014_accom_nonunity_vs_legacy():
+    """Non-unity accommodation correction agrees with legacy."""
+    V, T, P = 0.5, 283.15, 85000.0
+    smax_jax, _, _ = mbn2014_jax(V, T, P, accom=0.042, **SINGLE)
+    smax_leg, _, _ = mbn2014_legacy(V, T, P, accom=0.042, **SINGLE)
+    assert float(smax_jax) == pytest.approx(float(smax_leg), rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 2. Gradient check: IFT jax.grad vs central finite differences
+# ---------------------------------------------------------------------------
+
+_BASE = dict(V=0.5, T=283.15, P=85000.0, mus=[0.05], sigmas=[2.0], Ns=[300.0], kappas=[0.6])
+
+
+def _smax(**kw):
+    smax, _, _ = mbn2014_jax(**kw)
+    return smax
+
+
+def _fd_grad(param, delta, **base):
+    kw_p = dict(base)
+    kw_m = dict(base)
+    kw_p[param] = base[param] + delta
+    kw_m[param] = base[param] - delta
+    return (float(_smax(**kw_p)) - float(_smax(**kw_m))) / (2.0 * delta)
+
+
+@pytest.mark.parametrize(
+    "param, delta",
+    [
+        ("V", 1e-3),
+        ("T", 1e-2),
+        ("P", 10.0),
+    ],
+)
+def test_mbn2014_scalar_gradient(param, delta):
+    """IFT jax.grad w.r.t. scalar inputs matches central FD to 1e-2 relative.
+
+    The looser tolerance (vs ARG2000's 1e-4) reflects the bisection tolerance
+    floor: FD perturbs smax by ~tol, so the FD estimate itself carries ~1e-3
+    relative error relative to the true gradient.
+    """
+    base = dict(_BASE)
+
+    def fn(x):
+        kw = dict(base)
+        kw[param] = x
+        return _smax(**kw)
+
+    grad_jax = float(jax.grad(fn)(jnp.float64(base[param])))
+    grad_fd = _fd_grad(param, delta, **base)
+    assert grad_jax == pytest.approx(grad_fd, rel=1e-2)
+
+
+def test_mbn2014_gradient_wrt_N():
+    """IFT jax.grad of smax w.r.t. Ns[0] agrees with central FD."""
+    Ns = jnp.array([300.0])
+    V, T, P = 0.5, 283.15, 85000.0
+    mus = jnp.array([0.05])
+    sigmas = jnp.array([2.0])
+    kappas = jnp.array([0.6])
+
+    def fn(Ns):
+        smax, _, _ = mbn2014_jax(V, T, P, mus, sigmas, Ns, kappas)
+        return smax
+
+    grad_jax = float(jax.grad(fn)(Ns)[0])
+    dN = 1.0
+    grad_fd = (float(fn(Ns + dN)) - float(fn(Ns - dN))) / (2.0 * dN)
+    assert grad_jax == pytest.approx(grad_fd, rel=1e-2)
+
+
+def test_mbn2014_gradient_wrt_kappa():
+    """IFT jax.grad of smax w.r.t. kappas[0] agrees with central FD."""
+    kappas = jnp.array([0.6])
+    V, T, P = 0.5, 283.15, 85000.0
+    mus = jnp.array([0.05])
+    sigmas = jnp.array([2.0])
+    Ns = jnp.array([300.0])
+
+    def fn(kappas):
+        smax, _, _ = mbn2014_jax(V, T, P, mus, sigmas, Ns, kappas)
+        return smax
+
+    grad_jax = float(jax.grad(fn)(kappas)[0])
+    dk = 1e-3
+    grad_fd = (float(fn(kappas + dk)) - float(fn(kappas - dk))) / (2.0 * dk)
+    assert grad_jax == pytest.approx(grad_fd, rel=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# 3. Physical invariants
+# ---------------------------------------------------------------------------
+
+
+def test_mbn2014_smax_increases_with_updraft():
+    """Higher updraft → higher smax."""
+    Vs = [0.1, 0.3, 0.5, 1.0, 2.0]
+    smaxes = [float(mbn2014_jax(V, 283.15, 85000.0, **SINGLE)[0]) for V in Vs]
+    assert all(s1 < s2 for s1, s2 in zip(smaxes, smaxes[1:]))
+
+
+def test_mbn2014_act_fracs_in_unit_interval():
+    """Activated fractions must lie in [0, 1] for all test scenarios."""
+    for aerosol in [SINGLE, TWO_MODE, MARINE]:
+        for V, T, P in UPDRAFT_CONDITIONS:
+            _, _, fracs = mbn2014_jax(V, T, P, **aerosol)
+            assert jnp.all(fracs >= 0.0) and jnp.all(fracs <= 1.0)
+
+
+def test_mbn2014_smax_positive():
+    """smax must be strictly positive."""
+    smax, _, _ = mbn2014_jax(0.5, 283.15, 85000.0, **SINGLE)
+    assert float(smax) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 4. MBN2014 class interface
+# ---------------------------------------------------------------------------
+
+
+def test_mbn2014_class_matches_function():
+    """MBN2014() class gives identical results to the mbn2014() function."""
+    from pyrcel.activation import MBN2014
+
+    scheme = MBN2014()
+    V, T, P = 0.5, 283.15, 85000.0
+    smax_cls, N_cls, f_cls = scheme(V, T, P, **SINGLE)
+    smax_fn, N_fn, f_fn = mbn2014_jax(V, T, P, **SINGLE)
+    assert float(smax_cls) == pytest.approx(float(smax_fn), rel=1e-12)
+
+
+def test_mbn2014_class_call_time_accom_overrides_instance():
+    """Explicit accom at call time overrides the instance default."""
+    from pyrcel.activation import MBN2014
+
+    scheme = MBN2014(accom=1.0)
+    V, T, P = 0.5, 283.15, 85000.0
+    smax_default, _, _ = scheme(V, T, P, **SINGLE)
+    smax_override, _, _ = scheme(V, T, P, **SINGLE, accom=0.042)
+    assert float(smax_override) != pytest.approx(float(smax_default), rel=1e-4)
+
+
+def test_mbn2014_class_repr():
+    from pyrcel.activation import MBN2014
+
+    r = repr(MBN2014())
+    assert "MBN2014" in r
+
+
+def test_mbn2014_public_import():
+    """mbn2014 and MBN2014 are accessible from pyrcel top-level."""
+    import pyrcel
+
+    assert callable(pyrcel.MBN2014)
+    from pyrcel.activation import MBN2014, mbn2014  # noqa: F401


### PR DESCRIPTION
## Summary

- `pyrcel/activation/_mbn2014.py` — full JAX re-implementation of the Morales Betancourt & Nenes (2014) scheme
- `jax.lax.while_loop` bisection finds smax (JIT-compilable, O(log(1/tol)) iterations)
- Differentiability via **implicit function theorem** (`jax.custom_vjp`): ∂smax/∂θ = −(∂F/∂θ)/(∂F/∂smax) evaluated by a single `jax.grad` call on the algebraic residual at the converged root — no need to differentiate through the bisection loop
- `jnp.where` for the critical/non-critical population-splitting branch (scalar flag, vectorised over modes)
- Polynomial helpers (`_vpres_jax`, `_erfp_jax`) reproduce the legacy Nenes-group constants exactly for numerical agreement
- `MBN2014` class satisfies the `ActivationScheme` interface
- The legacy `mbn2014` re-export from `pyrcel.activation` is replaced by the JAX implementation; the NumPy original remains accessible at `pyrcel.legacy.activation.mbn2014`

## Test plan

- [x] 12 cross-check tests (3 aerosol scenarios × 4 updraft conditions): smax within 1e-5 relative of legacy
- [x] Activated fractions within 1e-4 relative of legacy
- [x] Non-unity accom correction vs legacy
- [x] 5 gradient tests (V, T, P, Ns, kappas): IFT grad vs central FD within 1e-2 relative
- [x] Physical invariants: smax monotone in V, fracs ∈ [0,1], smax > 0
- [x] `MBN2014` class interface and public import

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swapping the default `mbn2014` export changes behavior for callers that expected NumPy/SciPy; JAX bisection and IFT gradients add numerical edge cases, though tests heavily guard legacy parity.
> 
> **Overview**
> Adds a **JAX-native MBN2014** droplet activation scheme alongside ARG2000, exposed as `mbn2014` / `MBN2014` from `pyrcel.activation` and lazy `pyrcel.MBN2014`. Imports of `mbn2014` from `pyrcel.activation` now resolve to the JAX implementation; the NumPy reference stays at `pyrcel.legacy.activation.mbn2014`.
> 
> **smax** is found by JIT-friendly `jax.lax.while_loop` bisection on an implicit residual; backward mode uses **`jax.custom_vjp`** and the implicit function theorem so `jax.grad` works w.r.t. V, T, P, and aerosol inputs without differentiating through the loop. Legacy-matched polynomial helpers and vectorised population-splitting integrals keep numerical agreement with the legacy oracle.
> 
> New **`tests/test_mbn2014.py`** cross-checks smax and activated fractions vs legacy, validates IFT gradients against finite differences, checks physical monotonicity/bounds, and covers the `MBN2014` class and public imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecfd326fc482fe39c171c9e289ff786ae12dc1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->