### PR TITLE
feat(integrator): differentiable Nd via sigmoid soft threshold (issue #67)

### DIFF
--- a/pyrcel/activation/_arg2000.py
+++ b/pyrcel/activation/_arg2000.py
@@ -23,23 +23,7 @@ from jax.typing import ArrayLike  # noqa: E402
 
 from .. import constants as c  # noqa: E402
 from ..thermo import dv, dv_cont, es, ka_cont, sigma_w  # noqa: E402
-from ._common import _lognormal_act  # noqa: E402, F401
-
-
-def _kohler_crit_approx(T: ArrayLike, r_dry: ArrayLike, kappa: ArrayLike) -> tuple[Array, Array]:
-    """Approximate critical radius and supersaturation (JAX-traceable, kappa > 0).
-
-    Returns
-    -------
-    r_crit : float
-        Critical wet radius (m).
-    s_crit : float
-        Critical supersaturation (decimal).
-    """
-    A = (2.0 * c.Mw * sigma_w(T)) / (c.rho_w * c.R * T)
-    r_crit = jnp.sqrt((3.0 * kappa * r_dry**3) / A)
-    s_crit = jnp.sqrt((4.0 * A**3) / (27.0 * kappa * r_dry**3))
-    return r_crit, s_crit
+from ._common import _kohler_crit_approx, _lognormal_act  # noqa: E402, F401
 
 
 def arg2000(

--- a/pyrcel/activation/_common.py
+++ b/pyrcel/activation/_common.py
@@ -11,6 +11,9 @@ from jax import Array  # noqa: E402
 from jax.scipy.special import erfc  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
 
+from .. import constants as c  # noqa: E402
+from ..thermo import sigma_w  # noqa: E402
+
 
 def _lognormal_act(
     smax: ArrayLike, sigma: ArrayLike, N: ArrayLike, sgi: ArrayLike
@@ -38,3 +41,21 @@ def _lognormal_act(
     ui = 2.0 * jnp.log(sgi / smax) / (3.0 * jnp.sqrt(2.0) * jnp.log(sigma))
     N_act = 0.5 * N * erfc(ui)
     return N_act, N_act / N
+
+
+def _kohler_crit_approx(T: ArrayLike, r_dry: ArrayLike, kappa: ArrayLike) -> tuple[Array, Array]:
+    """Approximate critical radius and supersaturation (JAX-traceable, kappa > 0).
+
+    Vectorises over ``r_dry`` / ``kappa`` for scalar ``T``.
+
+    Returns
+    -------
+    r_crit : Array
+        Critical wet radius (m).
+    s_crit : Array
+        Critical supersaturation (decimal).
+    """
+    A = (2.0 * c.Mw * sigma_w(T)) / (c.rho_w * c.R * T)
+    r_crit = jnp.sqrt((3.0 * kappa * r_dry**3) / A)
+    s_crit = jnp.sqrt((4.0 * A**3) / (27.0 * kappa * r_dry**3))
+    return r_crit, s_crit

--- a/pyrcel/integrator.py
+++ b/pyrcel/integrator.py
@@ -31,6 +31,7 @@ import optimistix as optx  # noqa: E402
 from jax import Array  # noqa: E402
 from jax.typing import ArrayLike  # noqa: E402
 
+from .activation._common import _kohler_crit_approx  # noqa: E402
 from .parcel_aux import N_STATE_VARS, parcel_ode_sys  # noqa: E402
 from .updraft import ConstantV  # noqa: E402
 
@@ -203,6 +204,82 @@ def max_supersaturation(
         atol = atol_vector(nr)
     sol = _solve(y0, args, ts, rtol, atol, None, max_steps)
     return jnp.max(sol.ys[:, 6])
+
+
+def nd_from_parcel(
+    y0: ArrayLike,
+    args: tuple,
+    t_end: float,
+    *,
+    epsilon: float = 1e-8,
+    rtol: float = STATE_RTOL,
+    atol: ArrayLike | None = None,
+    max_steps: int = 100_000,
+) -> Array:
+    """Differentiable activated droplet number concentration via sigmoid soft threshold.
+
+    Integrates the parcel ODE to ``t_end`` and evaluates:
+
+    .. math::
+
+        N_d^{\\text{soft}} = \\sum_i N_i \\cdot \\sigma\\!\\left(
+            \\frac{r_i(t_{\\text{end}}) - r_{\\text{crit},i}}{\\varepsilon}
+        \\right)
+
+    where :math:`\\sigma` is the logistic sigmoid, :math:`r_{\\text{crit},i}` is
+    the approximate Köhler critical radius for bin *i*, and :math:`\\varepsilon`
+    controls the sharpness of the threshold.
+
+    Unlike the hard-threshold :attr:`~pyrcel.model.ParcelModel.Nd` diagnostic, this
+    function is fully differentiable with respect to ``y0`` and ``args`` via
+    ``diffrax``'s default ``RecursiveCheckpointAdjoint``::
+
+        dNd_dV = jax.grad(nd_from_parcel, argnums=1)(y0, args, t_end)[4].V
+
+    Parameters
+    ----------
+    y0 : array, shape ``(7 + nr,)``
+        Initial (equilibrated) state vector.
+    args : tuple
+        ``(r_drys, Nis, kappas, accom, V)`` for :func:`parcel_ode_sys`.
+        ``Nis`` must be in m⁻³ (the unit stored on ``AerosolSpecies.Nis``).
+    t_end : float
+        Integration time (s). Should extend past :math:`S_{\\text{max}}` so that
+        kinetically limited droplets have time to grow past their critical radius.
+    epsilon : float, optional
+        Sigmoid half-width (m). Controls the accuracy/smoothness trade-off:
+        smaller ``ε`` is more accurate but has a steeper gradient. Default
+        ``1e-8`` (≈ 10 nm, much smaller than a typical 100 nm critical radius).
+    rtol, atol : float or array, optional
+        Solver tolerances; defaults mirror the CVode-equivalent values.
+    max_steps : int, optional
+        Upper bound on adaptive ODE steps.
+
+    Returns
+    -------
+    Nd_soft : Array
+        Soft activated droplet number concentration (m⁻³) at ``t_end``.
+        In the limit ``ε → 0`` this converges to the hard-threshold count
+        using the approximate Köhler critical radius.
+    """
+    y0 = jnp.asarray(y0)
+    nr = int(y0.shape[0] - N_STATE_VARS)
+    if atol is None:
+        atol = atol_vector(nr)
+
+    ts = jnp.stack([jnp.zeros((), dtype=jnp.float64), jnp.asarray(t_end, dtype=jnp.float64)])
+    sol = _solve(y0, args, ts, rtol, atol, None, max_steps)
+
+    y_final = sol.ys[-1]  # shape (7 + nr,); T is state index 2
+    T_final = y_final[2]
+    rs_final = y_final[N_STATE_VARS:]  # wet radii (m), shape (nr,)
+
+    r_drys = jnp.asarray(args[0])
+    Nis = jnp.asarray(args[1])
+    kappas = jnp.asarray(args[2])
+
+    r_crits, _ = _kohler_crit_approx(T_final, r_drys, kappas)
+    return jnp.sum(Nis * jax.nn.sigmoid((rs_final - r_crits) / epsilon))
 
 
 # --- Event-based S_max termination (design §4.5 option A) -------------------------

--- a/tests/test_nd_adjoint.py
+++ b/tests/test_nd_adjoint.py
@@ -1,0 +1,224 @@
+"""Tests for nd_from_parcel: differentiable Nd via sigmoid soft threshold (issue #67).
+
+Covers:
+1. Basic correctness: positive float, units/scale consistent with hard Nd
+2. Soft→hard limit: at ε=1e-10 agrees with hard-threshold Nd within 10%
+3. Differentiability: jax.grad runs and returns finite values for y0 and args
+4. FD gradient check: JAX gradient vs central-difference for V and Ns
+5. JIT compatibility
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import pyrcel as pm
+from pyrcel import AerosolSpecies, Lognorm
+from pyrcel.integrator import nd_from_parcel
+
+jax.config.update("jax_enable_x64", True)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: simple single-mode parcel
+# ---------------------------------------------------------------------------
+
+T0, S0, P0 = 283.15, 0.0, 85000.0
+V0 = 0.5
+_AER = AerosolSpecies("sulfate", Lognorm(mu=0.05, sigma=2.0, N=300.0), kappa=0.6, bins=8)
+_T_END = 300.0
+_EPS_TIGHT = 1e-10
+
+
+@pytest.fixture(scope="module")
+def parcel_setup():
+    """Return a ready-to-go (y0, args, t_end) triple for the single-mode test parcel."""
+    model = pm.ParcelModel([_AER], V=V0, T0=T0, S0=S0, P0=P0)
+    return model.y0, model.args, _T_END
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic sanity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_nd_soft_returns_finite_positive(parcel_setup):
+    y0, args, t_end = parcel_setup
+    nd = nd_from_parcel(y0, args, t_end, epsilon=1e-8)
+    assert float(nd) > 0.0
+    assert np.isfinite(float(nd))
+
+
+@pytest.mark.slow
+def test_nd_soft_scale_consistent_with_hard(parcel_setup):
+    """Soft Nd should be in the same ballpark as the hard diagnostic."""
+    y0, args, t_end = parcel_setup
+    model = pm.ParcelModel([_AER], V=V0, T0=T0, S0=S0, P0=P0)
+    model.run(t_end=t_end, output_dt=5.0)
+    nd_hard = model.summary()["total_Nd"]
+
+    nd_soft = float(nd_from_parcel(y0, args, t_end, epsilon=1e-8))
+    # Same order of magnitude (within factor 3) — loose check on scale only
+    assert nd_soft / nd_hard > 0.33
+    assert nd_soft / nd_hard < 3.0
+
+
+# ---------------------------------------------------------------------------
+# 2. Soft → hard limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_nd_soft_tight_eps_matches_hard(parcel_setup):
+    """At ε=1e-10, soft Nd should be within 10% of hard Nd.
+
+    Residual discrepancy comes from the approx vs exact Köhler r_crit, not
+    from sigmoid smoothing.
+    """
+    y0, args, t_end = parcel_setup
+    model = pm.ParcelModel([_AER], V=V0, T0=T0, S0=S0, P0=P0)
+    model.run(t_end=t_end, output_dt=5.0)
+    nd_hard = model.summary()["total_Nd"]
+
+    nd_soft = float(nd_from_parcel(y0, args, t_end, epsilon=_EPS_TIGHT))
+    rel_err = abs(nd_soft - nd_hard) / nd_hard
+    assert rel_err < 0.10, f"rel_err={rel_err:.3%}"
+
+
+@pytest.mark.slow
+def test_nd_soft_monotone_in_eps(parcel_setup):
+    """Nd_soft should be roughly monotone as ε shrinks toward the hard limit."""
+    y0, args, t_end = parcel_setup
+    model = pm.ParcelModel([_AER], V=V0, T0=T0, S0=S0, P0=P0)
+    model.run(t_end=t_end, output_dt=5.0)
+    nd_hard = model.summary()["total_Nd"]
+
+    prev_err = float("inf")
+    for eps in [1e-6, 1e-8, 1e-10]:
+        nd = float(nd_from_parcel(y0, args, t_end, epsilon=eps))
+        err = abs(nd - nd_hard)
+        assert err < prev_err * 1.5, f"Nd not converging as ε→0: eps={eps}, err={err}"
+        prev_err = err
+
+
+# ---------------------------------------------------------------------------
+# 3. Differentiability: grad runs without error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_grad_wrt_y0_is_finite(parcel_setup):
+    y0, args, t_end = parcel_setup
+
+    def fn(y0_):
+        return nd_from_parcel(y0_, args, t_end, epsilon=1e-8)
+
+    grad_y0 = jax.grad(fn)(jnp.asarray(y0))
+    assert np.all(np.isfinite(np.asarray(grad_y0)))
+
+
+@pytest.mark.slow
+def test_grad_wrt_args_is_finite(parcel_setup):
+    """Gradient flows through the ODE and the Köhler computation."""
+    y0, args, t_end = parcel_setup
+    r_drys, Nis, kappas, accom, V = args
+
+    def fn(r_drys_, Nis_, kappas_):
+        new_args = (r_drys_, Nis_, kappas_, accom, V)
+        return nd_from_parcel(y0, new_args, t_end, epsilon=1e-8)
+
+    grad_r, grad_N, grad_k = jax.grad(fn, argnums=(0, 1, 2))(
+        jnp.asarray(r_drys), jnp.asarray(Nis), jnp.asarray(kappas)
+    )
+    for name, g in [("r_drys", grad_r), ("Nis", grad_N), ("kappas", grad_k)]:
+        assert np.all(np.isfinite(np.asarray(g))), f"non-finite gradient w.r.t. {name}"
+
+
+# ---------------------------------------------------------------------------
+# 4. FD gradient check for V and N
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_grad_V_fd_check(parcel_setup):
+    """d(Nd)/d(V) via JAX autodiff should match central-difference to ~1%."""
+    y0, args, t_end = parcel_setup
+    r_drys, Nis, kappas, accom, _V = args
+    V_base = float(_V.V) if hasattr(_V, "V") else float(_V)
+
+    from pyrcel.updraft import ConstantV
+
+    def fn(V_val):
+        new_args = (r_drys, Nis, kappas, accom, ConstantV(V_val))
+        return nd_from_parcel(y0, new_args, t_end, epsilon=1e-8)
+
+    V_jax = jnp.float64(V_base)
+    grad_jax = float(jax.grad(fn)(V_jax))
+
+    dV = V_base * 1e-3
+    grad_fd = float((fn(jnp.float64(V_base + dV)) - fn(jnp.float64(V_base - dV))) / (2 * dV))
+
+    if abs(grad_fd) > 1e-6:
+        rel_err = abs(grad_jax - grad_fd) / abs(grad_fd)
+        assert rel_err < 0.05, f"JAX={grad_jax:.4g} FD={grad_fd:.4g} rel_err={rel_err:.3%}"
+    else:
+        assert abs(grad_jax - grad_fd) < 1e-3
+
+
+@pytest.mark.slow
+def test_grad_N_fd_check(parcel_setup):
+    """d(Nd)/d(N_i) via autodiff vs FD for the first bin."""
+    y0, args, t_end = parcel_setup
+    r_drys, Nis_arr, kappas, accom, V = args
+    Nis_base = jnp.asarray(Nis_arr)
+
+    def fn(Nis_):
+        new_args = (r_drys, Nis_, kappas, accom, V)
+        return nd_from_parcel(y0, new_args, t_end, epsilon=1e-8)
+
+    grad_N = np.asarray(jax.grad(fn)(Nis_base))
+
+    # FD for bin 0 only (to keep wall time reasonable)
+    dN = float(Nis_base[0]) * 1e-4
+    Nis_p = Nis_base.at[0].add(dN)
+    Nis_m = Nis_base.at[0].add(-dN)
+    grad_fd_0 = float((fn(Nis_p) - fn(Nis_m)) / (2 * dN))
+
+    if abs(grad_fd_0) > 1e-4:
+        rel_err = abs(float(grad_N[0]) - grad_fd_0) / abs(grad_fd_0)
+        assert rel_err < 0.05, f"JAX={float(grad_N[0]):.4g} FD={grad_fd_0:.4g} rel_err={rel_err:.3%}"
+    else:
+        assert abs(float(grad_N[0]) - grad_fd_0) < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# 5. JIT compatibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_jit_nd_from_parcel(parcel_setup):
+    y0, args, t_end = parcel_setup
+    fn_jit = jax.jit(nd_from_parcel, static_argnames=("max_steps",))
+    nd1 = float(fn_jit(y0, args, t_end, epsilon=1e-8))
+    nd2 = float(fn_jit(y0, args, t_end, epsilon=1e-8))
+    assert nd1 == pytest.approx(nd2, rel=1e-12)
+    assert nd1 > 0.0
+
+
+@pytest.mark.slow
+def test_jit_grad_nd_from_parcel(parcel_setup):
+    """jax.jit(jax.grad(nd_from_parcel)) should execute without error."""
+    y0, args, t_end = parcel_setup
+
+    def fn(y0_):
+        return nd_from_parcel(y0_, args, t_end, epsilon=1e-8)
+
+    grad_fn = jax.jit(jax.grad(fn))
+    g = np.asarray(grad_fn(jnp.asarray(y0)))
+    assert g.shape == jnp.asarray(y0).shape
+    assert np.all(np.isfinite(g))

--- a/tests/test_nd_adjoint.py
+++ b/tests/test_nd_adjoint.py
@@ -190,7 +190,9 @@ def test_grad_N_fd_check(parcel_setup):
 
     if abs(grad_fd_0) > 1e-4:
         rel_err = abs(float(grad_N[0]) - grad_fd_0) / abs(grad_fd_0)
-        assert rel_err < 0.05, f"JAX={float(grad_N[0]):.4g} FD={grad_fd_0:.4g} rel_err={rel_err:.3%}"
+        assert rel_err < 0.05, (
+            f"JAX={float(grad_N[0]):.4g} FD={grad_fd_0:.4g} rel_err={rel_err:.3%}"
+        )
     else:
         assert abs(float(grad_N[0]) - grad_fd_0) < 1e-3
 


### PR DESCRIPTION
## Summary

- Moves `_kohler_crit_approx` from `activation/_arg2000.py` to `activation/_common.py` — it now has two consumers (ARG2000 and the integrator), so the shared module is the right home.
- Adds `nd_from_parcel(y0, args, t_end, *, epsilon=1e-8, ...)` to `pyrcel/integrator.py`. It runs the fixed-horizon ODE to `t_end` and evaluates:

$$N_d^{\text{soft}} = \sum_i N_i \cdot \sigma\!\left(\frac{r_i(t_{\text{end}}) - r_{\text{crit},i}}{\varepsilon}\right)$$

  where $\sigma$ is the logistic sigmoid and $r_{\text{crit},i}$ comes from the approximate Köhler formula. Gradients flow through the ODE via diffrax's default `RecursiveCheckpointAdjoint` — no extra setup needed.

- Adds `tests/test_nd_adjoint.py` with 10 tests.

## Design notes

**Why `_solve` (not a new `_solve_final`)?** The existing `_solve` with `ts = [0, t_end]` produces two saved time points. For `RecursiveCheckpointAdjoint`, adjoint memory is O(√N_steps) regardless of saved outputs, so this adds negligible cost vs a `SaveAt(t1=True)` variant — and avoids duplicating the JIT-compiled solve.

**`epsilon` default = 1e-8 m (≈10 nm).** Typical r_crit is ~100 nm, so a 10 nm half-width keeps the sigmoid effectively hard except within ±30 nm of the threshold. Gradient magnitude is `∂σ/∂r = σ(1−σ)/ε ≈ 1/4ε` at the threshold — users can widen ε for smoother gradients if needed.

**Köhler approximation vs exact.** The soft limit (ε→0) converges to a hard threshold using `_kohler_crit_approx`, not the full Köhler solve used by `binned_activation`. The 10% tolerance in `test_nd_soft_tight_eps_matches_hard` covers this residual discrepancy.

## Test plan

- [x] `uv run pytest tests/ -m "not slow" -x -q` — 228 passed (fast suite, verifies refactor)
- [x] `uv run pytest tests/test_nd_adjoint.py -v` — 10 passed (soft Nd + gradients)
- [x] `uv run pyrefly check pyrcel/activation/_common.py pyrcel/activation/_arg2000.py pyrcel/integrator.py` — 0 errors

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new differentiable diagnostic on the stiff parcel ODE adjoint path; behavior depends on ε and approximate Köhler r_crit rather than the model's exact activation diagnostic, but changes are additive with shared-helper refactor only.
> 
> **Overview**
> Adds **`nd_from_parcel`**, a fixed-horizon parcel integration path that returns a **soft activated droplet count** (m⁻³) by summing bin concentrations weighted with a logistic sigmoid on wet radius minus approximate Köhler **r_crit** at `t_end`. Gradients w.r.t. `y0` and aerosol/updraft `args` flow through the existing diffrax solve (same pattern as `max_supersaturation`), enabling sensitivity work on Nd without the hard threshold on `ParcelModel.Nd`.
> 
> **`_kohler_crit_approx`** is relocated from `activation/_arg2000.py` into **`activation/_common.py`** so ARG2000 and the integrator share one JAX-traceable helper; the docstring now notes vectorization over bins.
> 
> New **`tests/test_nd_adjoint.py`** exercises scale vs hard Nd, ε→0 convergence, `jax.grad` finiteness, FD checks on **V** and **N**, and JIT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ce0257cb4a385525794bd705a7fc4ec7c57903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->