### PR TITLE
fix: post-hoc Hermite cubic S_max finder + live/no-terminate NaN fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ aerosol-cloud interaction studies. [Rothenberg and Wang (2016)](http://journals.
 
 [Detailed documentation is available](https://pyrcel.readthedocs.io/en/latest/), including a [scientific description](https://pyrcel.readthedocs.io/en/latest/user_guide/sci_descr/), [installation details](https://pyrcel.readthedocs.io/en/latest/getting_started/installation/), and a [basic example](https://pyrcel.readthedocs.io/en/latest/examples/basic_run/).
 
+> [!WARNING]
+> **Version 2.0 Notice**
+>
+> This is **pyrcel v2.0**, a major new release with more features, greater flexibility, and a JAX-based differentiable kernel. However, there are several **breaking changes** compared to version 1.3.x.
+>
+> Please review the [migration guide](https://pyrcel.readthedocs.io/en/latest/user_guide/migration/) to update your code.
+>
+> If you wish to continue using the legacy (v1.3.x) model, you can install it from PyPI by pinning the version:
+>
+> ```shell
+> pip install "pyrcel<2"
+> ```
+
+
 Quick Start
 -----------
 
@@ -37,9 +51,11 @@ import pyrcel as pm
 sulfate = pm.AerosolSpecies(
     "sulfate", pm.Lognorm(mu=0.05, sigma=2.0, N=1000.0), kappa=0.54, bins=50
 )
-model = pm.ParcelModel([sulfate], V=1.0, T0=283.15, S0=-0.02, P0=85000.0, console=True)
-output = model.run(t_end=200.0, output_dt=1.0, terminate=True)
-print(output.summary["S_max"])
+model = pm.ParcelModel([sulfate], V=1.0, T0=283.0, S0=-0.02, P0=85000.0, console=True)
+output = model.run(t_end=300.0, output_dt=10.0, terminate=True, live=True)
+
+print(f"S_max  = {output.summary['S_max']*100:.3f} %")
+print(f"N_act  = {output.Nd:.3e} m⁻³")
 ```
 
 Key capabilities:
@@ -139,7 +155,10 @@ original publication detailing the model:
       url = "https://journals.ametsoc.org/view/journals/atsc/73/3/jas-d-15-0223.1.xml"
 }
 ```
-
+Additionally, please consider citing the bespoke DOI for the
+[specific release version of pyrcel](https://zenodo.org/records/20693507)
+that you used during your research (or the base version you modified). This
+allows us to track adoption and use of specific model versions over time.
 
 [author_email]: mailto:daniel@danielrothenberg.com
 [nenes2001]: https://onlinelibrary.wiley.com/doi/abs/10.1034/j.1600-0889.2001.d01-12.x

--- a/docs/examples/basic_run.md
+++ b/docs/examples/basic_run.md
@@ -1,14 +1,15 @@
 # Basic Run
 
-A single parcel simulation from initial conditions through droplet activation.
-Demonstrates the core API: constructing an aerosol population, running the model,
-and accessing the trajectory and activation diagnostics.
+A single parcel simulation from initial conditions through droplet activation,
+using a two-mode aerosol population (accumulation + Aitken). Demonstrates the
+core API: constructing an aerosol population, running the model, and accessing
+the trajectory and activation diagnostics.
 
 **Script:** [`examples/basic_run.py`](https://github.com/darothen/pyrcel/blob/master/examples/basic_run.py)
 
 ```bash
 python examples/basic_run.py
-python examples/basic_run.py --V 0.5 --N 2000 --mu 0.05 --kappa 0.54 \
+python examples/basic_run.py --V 0.5 --T0 283.0 --t-end 200.0 \
     --out output/run.nc --plot output/run.png
 ```
 
@@ -17,18 +18,29 @@ python examples/basic_run.py --V 0.5 --N 2000 --mu 0.05 --kappa 0.54 \
 ```python
 import pyrcel as pm
 
-aerosol = pm.AerosolSpecies(
-    "sulfate",
-    pm.Lognorm(mu=0.05e-6, sigma=2.0, N=1000.0),
+accumulation = pm.AerosolSpecies(
+    "accumulation",
+    pm.Lognorm(mu=0.05, sigma=2.0, N=1000.0),  # mu in µm
     kappa=0.54,
-    bins=100,
+    bins=50,
+)
+aitken = pm.AerosolSpecies(
+    "aitken",
+    pm.Lognorm(mu=0.01, sigma=1.6, N=2000.0),  # mu in µm
+    kappa=0.3,
+    bins=50,
 )
 
 model = pm.ParcelModel(
-    [aerosol], V=1.0, T0=283.15, S0=-0.02, P0=85000.0, console=True
+    [accumulation, aitken], V=1.0, T0=283.0, S0=-0.02, P0=85000.0, console=True
 )
-out = model.run(t_end=300.0, output_dt=1.0)
+out = model.run(100.0, output_dt=1.0, terminate=False, progress=True)
 ```
+
+The accumulation mode ($\mu = 50$ nm, $\sigma = 2.0$, $\kappa = 0.54$) represents
+sulfate-like particles that activate readily. The Aitken mode ($\mu = 10$ nm,
+$\sigma = 1.6$, $\kappa = 0.3$) is smaller and less hygroscopic; only a small
+fraction of Aitken bins exceed their critical supersaturation at this updraft speed.
 
 ## Activation summary
 
@@ -45,10 +57,11 @@ axis) as functions of height. The supersaturation rises as the parcel lifts, pea
 $S_\text{max}$ (dashed gold line), then falls as condensation depletes water vapor faster
 than adiabatic cooling can generate it.
 
-**Right panel** — size evolution of a sub-sample of aerosol bins from both modes.
-Bold solid traces are activated droplets ($s_\text{crit} < S_\text{max}$); dashed traces
-remain as haze. The kink in each activated trace marks the moment the droplet crosses its
-Köhler critical radius and begins growing freely.
+**Right panel** — size evolution of a sub-sample of aerosol bins from both modes
+(teal = accumulation, orange = Aitken). Bold solid traces are activated droplets
+($S_\text{crit} < S_\text{max}$); dashed traces remain as haze. The kink in each
+activated trace marks the moment the droplet crosses its Köhler critical radius and
+begins growing freely.
 
 ## Saving output
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,19 @@ droplets activated at cloud base.
 
 ![Parcel model simulation: supersaturation and aerosol size evolution](assets/figures/basic_run.png)
 
+!!! warning "Version 2.0 Notice"
+
+    This is **pyrcel v2.0**, a major new release with more features, greater flexibility, and a JAX-based differentiable kernel. However, there are several **breaking changes** compared to version 1.3.x.
+
+    Please review the [migration guide](user_guide/migration.md) to update your code.
+
+    If you wish to continue using the legacy (v1.3.x) model, you can install it from PyPI by pinning the version:
+
+    ```shell
+    pip install "pyrcel<2"
+    ```
+
+
 ## Highlights
 
 **Differentiable.** Every output is a smooth function of its inputs. Compute
@@ -43,18 +56,71 @@ and GitHub installs.
 ```python
 import pyrcel as pm
 
-aerosol = pm.AerosolSpecies(
-    "sulfate",
-    pm.Lognorm(mu=0.05e-6, sigma=2.0, N=1000.0),
-    kappa=0.6,
-    bins=100,
+sulfate = pm.AerosolSpecies(
+    "sulfate", pm.Lognorm(mu=0.05, sigma=2.0, N=1000.0), kappa=0.54, bins=50
 )
-model = pm.ParcelModel([aerosol], V=1.0, T0=283.15, S0=-0.02, P0=85000.0)
-out   = model.run(t_end=300.0, output_dt=1.0)
+model = pm.ParcelModel([sulfate], V=1.0, T0=283.0, S0=-0.02, P0=85000.0, console=True)
+output = model.run(t_end=300.0, output_dt=10.0, terminate=True, live=True)
 
-print(f"S_max  = {out.summary['S_max']*100:.3f} %")
-print(f"N_act  = {out.Nd:.3e} m⁻³")
+print(f"S_max  = {output.summary['S_max']*100:.3f} %")
+print(f"N_act  = {output.Nd:.3e} m⁻³")
 ```
+
+??? note "Click to expand sample output"
+
+    ```
+    Parcel model (JAX / diffrax)
+    ------------------------------------------------------------------------
+      Backend   JAX 0.10.1 | cpu:0 | float64=on
+
+      Configuration
+        V            1 m/s              accom        1
+        T0           283.00 K           P0           850.0 hPa
+        S0           -0.02000 (-2.00 %)    bins         50
+
+      species           κ     N [cm⁻³]   bins  size
+      --------------------------------------------------------------------
+      sulfate       0.540       1002.4     50  μ=0.05 μm  σ=2
+
+      Equilibrated initial state
+        equilibration   520.3 ms  |Seq-S0|_max = 1.49e-16
+           P    850.0 hPa     T  283.00 K    wv     8.84 g/kg    wc 1.05e-04 g/kg     S -0.02000
+    ------------------------------------------------------------------------
+
+      Integration plan
+        t_end cap     300 s
+        output_dt     10 s
+        terminate     yes (+10 m past S_max)
+        solver        Kvaerno5 + PIDController  rtol=1e-07  max_steps=100000
+        progress      live chunk loop (10 s chunks)
+    ------------------------------------------------------------------------
+
+      Integration loop
+
+        step     time  walltime  Δwalltime |     z       T       S
+       ------------------------------------|----------------------
+           1    0.00s     0.00s      0.00s |   0.0  283.00  -2.00%
+           2   10.00s     2.45s      2.45s |  10.0  282.90  -1.53%
+           3   20.00s     2.47s      0.02s |  20.0  282.80  -1.05%
+           4   30.00s     2.49s      0.02s |  30.0  282.71  -0.58%
+           5   40.00s     2.52s      0.03s |  40.0  282.61  -0.12%
+           6   50.00s     2.56s      0.04s |  50.0  282.52   0.25%
+           7   60.00s     2.58s      0.02s |  60.0  282.47   0.20%
+       ---- end of integration loop ----
+
+    [pyrcel] Termination: S_max = 0.2691 % at t = 52.50 s (z = 52.5 m); stopped at t = 62.50 s (z = 62.5 m).
+
+      Simulation summary
+    ------------------------------------------------------------------------
+      S_max = 0.2691 %  at t = 52.50 s (T = 282.52 K, z = 50.0 m)
+           species   eq_act   kn_act      N_act          N
+           sulfate    0.637    0.570 638373012.4 1002378640.4
+      total activated fraction = 0.637
+    ------------------------------------------------------------------------
+
+    S_max  = 0.269 %
+    N_act  = 6.384e+08 m⁻³
+    ```
 
 ---
 

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -1,0 +1,237 @@
+# Best Practices
+
+Short, opinionated tips for the most common pyrcel v2 workflows. Each section
+targets a specific question; follow the cross-links for full derivations.
+
+---
+
+## Choosing output times for `max_supersaturation`
+
+The output-time array `ts` passed to `max_supersaturation` is used only to
+locate the supersaturation peak bracket; the actual maximum is refined on the
+solver's continuous Hermite interpolant and corrected to near-machine-precision
+by a Newton step (see
+[Numerical Methods — Differentiable $S_\text{max}$](numerical_methods.md#differentiable-s_max-dense-interpolation-and-newton-refinement)).
+Three rules apply:
+
+**1. The peak must lie strictly inside `[ts[0], ts[-1]]`.**
+If `ts[-1]` is before the peak, `max_supersaturation` returns the value at
+`ts[-1]`, not the true $S_\text{max}$, and the gradient is wrong. A reliable
+upper bound is $z_\text{target} \approx 1500$ m above cloud base:
+
+$$
+t_\text{end} = \frac{1500\,\text{m}}{V}, \quad \text{clamped to }
+[200\,\text{s},\, 15\,000\,\text{s}]
+$$
+
+**2. Fix the array *shape* across calls to share the JIT cache.**
+The XLA kernel is respecialised whenever `ts.shape[0]` changes. Keep
+`n_output` constant and vary only `t_end`:
+
+```python
+N_TS = 600   # constant: one JIT compilation for all V
+
+def ts_for_V(V: float) -> jnp.ndarray:
+    t_end = float(max(200.0, min(1500.0 / V, 15000.0)))
+    return jnp.linspace(0.0, t_end, N_TS)
+```
+
+**3. `t_end ∝ 1/V` does not bias gradients.**
+By the envelope theorem, $\partial S_\text{max}/\partial t_\text{end} = 0$
+whenever the peak is in the interior, so scaling `t_end` with $V$ introduces
+no gradient error.
+
+---
+
+## When to use each diagnostic function
+
+| Task | Function | Notes |
+|---|---|---|
+| Forward simulation + trajectory | `integrate_parcel` / `integrate_parcel_arrays` | Returns full state history |
+| Interactive run with termination | `ParcelModel.run(terminate=True)` | Uses event detection; not differentiable |
+| Differentiable $S_\text{max}$ | `max_supersaturation(y0, args, ts)` | Dense interpolant + Newton; `jax.grad`-able |
+| Differentiable $N_d$ | `nd_from_parcel(y0, args, t_end)` | Sigmoid soft threshold; `jax.grad`-able |
+| Precise $t_{S_\text{max}}$ location | `find_smax(y0, args, t_end)` | Event-based; **not** differentiable |
+| MBN2014 parameterisation gradient | `mbn2014_smax(...)` | IFT custom VJP; exact gradient |
+
+For gradient-based workflows (`jax.grad`, `jax.jacfwd`, optimisation loops)
+always use `max_supersaturation` or `nd_from_parcel`. `find_smax` and the
+`terminate=True` path contain data-dependent branches that JAX cannot
+differentiate.
+
+---
+
+## Setting up a gradient computation
+
+A minimal checklist for a correct `jax.grad` call:
+
+```python
+import jax
+import jax.numpy as jnp
+import pyrcel as pm
+from pyrcel.integrator import max_supersaturation, atol_vector
+from pyrcel.equilibrate import equilibrate_initial_state
+
+# 1. Build initial state (must be JAX-traceable)
+y0 = equilibrate_initial_state(T0, S0, P0, r_drys, kappas, Nis)
+
+# 2. Build args tuple
+V  = pm.ConstantV(v_val)
+args = (r_drys, Nis, kappas, accom, V)
+
+# 3. Choose ts: fixed shape, t_end past S_max
+ts = jnp.linspace(0.0, 1500.0 / v_val, 600)
+
+# 4. Warm up JIT (first call compiles; subsequent calls are fast)
+_ = jax.block_until_ready(max_supersaturation(y0, args, ts))
+
+# 5. Differentiate
+grad_fn = jax.grad(max_supersaturation, argnums=1)
+grad_args = grad_fn(y0, args, ts)
+dSmax_dV = grad_args[4].V   # ConstantV wraps V as an Equinox module
+```
+
+Common mistakes:
+
+- **Passing Python floats instead of JAX arrays** for `r_drys`, `Nis`, or
+  `kappas` — wrap with `jnp.asarray(...)` before building `args`.
+- **Using `nd_from_parcel` without sufficient `t_end`** — if `t_end` is before
+  the activated droplets grow past their critical radii the soft $N_d$ will
+  undercount. A rule of thumb is `t_end ≥ 2 × t_{S_\text{max}}`.
+- **Calling `jax.grad` inside a `vmap` on the first execution** — always warm
+  up the JIT kernel with a scalar call first.
+
+---
+
+## Epsilon choice for `nd_from_parcel`
+
+The sigmoid half-width $\varepsilon$ controls the accuracy / smoothness
+trade-off for the differentiable droplet number:
+
+$$
+N_d^{\text{soft}} = \sum_i N_i\, \sigma\!\left(\frac{r_i - r_{\text{crit},i}}{\varepsilon}\right)
+$$
+
+| $\varepsilon$ (m) | Typical error vs. hard threshold | Gradient magnitude | When to use |
+|---|---|---|---|
+| $10^{-7}$ (100 nm) | $\lesssim 1\%$ | small near threshold | Smooth landscapes, far from threshold |
+| $10^{-8}$ (10 nm) | $\lesssim 10\%$ | moderate | **Default** — balances accuracy and smoothness |
+| $10^{-9}$ (1 nm) | $\lesssim 20\%$ | large near threshold | Optimisation requiring sharp $N_d$ |
+
+The residual discrepancy vs. the hard threshold comes from the approximate
+Köhler formula used for $r_\text{crit}$, not from $\varepsilon$; reducing
+$\varepsilon$ below $10^{-9}$ increases gradient magnitude without improving
+accuracy relative to exact activation.
+
+---
+
+## Tolerance tuning
+
+The defaults (`rtol=1e-7`, `atol` per-component vector) match the legacy CVode
+configuration and are correct for the vast majority of simulations. Tighten
+tolerances when:
+
+- **Running `jax.grad` at high updraft speed or small particle size** — if you
+  see `EquinoxRuntimeError: A linear solver returned non-finite output` during
+  the adjoint backward pass, try `rtol=1e-9` and radius `atol=1e-14`. See
+  [Adjoint conditioning failures](numerical_methods.md#adjoint-conditioning-failures).
+
+- **Very high aerosol concentration** ($N \gtrsim 10^4$ cm$^{-3}$ with $\geq
+  200$ bins) — the stiffness ratio grows near activation; tighter tolerances
+  suppress spurious oscillations in the radius trajectories.
+
+To override tolerances:
+
+```python
+from pyrcel.integrator import atol_vector
+import jax.numpy as jnp
+
+nr = r_drys.shape[0]
+tight_atol = jnp.concatenate([
+    jnp.array([1e-4, 1e-4, 1e-4, 1e-10, 1e-10, 1e-4, 1e-8]),
+    jnp.full(nr, 1e-14),
+])
+smax = max_supersaturation(y0, args, ts, rtol=1e-9, atol=tight_atol)
+```
+
+---
+
+## JIT warm-up and timing
+
+The first call to any JAX-compiled function triggers trace + XLA compilation,
+which takes 10–30 s for a 200-bin simulation. Always warm up before timing:
+
+```python
+import time, jax
+from pyrcel.integrator import max_supersaturation
+
+# Warm up — discards result but fills the JIT cache
+_ = jax.block_until_ready(max_supersaturation(y0, args, ts))
+
+# Now time the actual computation
+t0 = time.perf_counter()
+smax = float(jax.block_until_ready(max_supersaturation(y0, args, ts)))
+print(f"S_max = {smax:.5f}  [{time.perf_counter() - t0:.3f} s]")
+```
+
+The compiled kernel is shape-specialised: any change in `ts.shape[0]` or
+`y0.shape[0]` (i.e. bin count) triggers a new compilation. Plan your bin
+counts before production sweeps.
+
+---
+
+## Ensemble runs with `jax.vmap`
+
+For a batch of simulations that share the same ODE shape (same number of bins)
+but differ in parameters, `jax.vmap` compiles a single batched kernel:
+
+```python
+import jax
+
+V_samples = jnp.linspace(0.1, 3.0, 256)
+
+def smax_for_V(V_val):
+    ts_v = ts_for_V(float(V_val))  # V-scaled horizon, fixed shape
+    new_args = (r_drys, Nis, kappas, accom, pm.ConstantV(V_val))
+    return max_supersaturation(y0, new_args, ts_v)
+
+# First warm up a scalar call
+_ = jax.block_until_ready(smax_for_V(V_samples[0]))
+
+# Then batch
+smax_batch = jax.jit(jax.vmap(smax_for_V))(V_samples)  # shape (256,)
+```
+
+`jax.vmap` over `ConstantV` works because `ConstantV` is an
+[Equinox](https://github.com/patrick-kidger/equinox) module and its `V`
+attribute is a JAX array leaf. For `InterpolatedUpdraft`, batch over the
+amplitude scalar rather than the full module.
+
+For convenience, `ParcelModel.run_updraft_ensemble` wraps this pattern for
+updraft-speed ensembles; see [Updraft Ensemble](../examples/updraft_ensemble.md).
+
+---
+
+## Gradient vs. finite-difference verification
+
+Before trusting a gradient, verify it against a central finite-difference
+estimate:
+
+```python
+eps = 1e-4  # perturbation size for the parameter being tested
+
+smax_plus  = float(max_supersaturation(y0, args_plus(eps),  ts))
+smax_minus = float(max_supersaturation(y0, args_minus(eps), ts))
+fd_grad = (smax_plus - smax_minus) / (2 * eps)
+
+adjoint_grad = float(jax.grad(max_supersaturation, argnums=1)(y0, args, ts)[4].V)
+
+ratio = adjoint_grad / fd_grad
+print(f"adjoint / FD = {ratio:.4f}")   # should be 0.999–1.001
+```
+
+A ratio outside $[0.99, 1.01]$ indicates one of: insufficient `ts` coverage
+(peak not bracketed), adjoint conditioning failure, or a numerical issue with
+the perturbation size.  See
+[Numerical Methods](numerical_methods.md#adjoint-conditioning-failures)
+for a diagnosis checklist.

--- a/docs/user_guide/numerical_methods.md
+++ b/docs/user_guide/numerical_methods.md
@@ -179,6 +179,16 @@ diagnostics, at the cost of JIT overhead per chunk and incompatibility with
 `jax.grad`. See the [migration guide](migration.md) for the full display-option
 comparison (`progress`, `live`, `trajectory_table`).
 
+For interactive runs without early termination (`terminate=False`), $S_\text{max}$
+is located post-hoc from the saved trajectory rather than by a second ODE solve.
+The interactive layer constructs cubic Hermite polynomials over the two
+sub-intervals bracketing the discrete argmax, using `parcel_ode_sys` to supply
+the exact endpoint derivatives $\dot{S}$ — the same polynomial family diffrax
+stores per solver step when `SaveAt(dense=True)` is used — and finds the
+analytic maximum by solving the resulting quadratic $dp/du = 0$. The cost is
+three RHS evaluations; the accuracy is O($\Delta t^4$) where $\Delta t$ is the
+output spacing.
+
 ---
 
 ## Supersaturation-maximum event detection
@@ -216,7 +226,7 @@ through a data-dependent control-flow decision. As a result,
 instead:
 
 ```python
-# Differentiable: fixed t_end, S_max found as argmax over output grid
+# Differentiable: dense interpolant + Newton refinement (exact via envelope theorem)
 from pyrcel.integrator import max_supersaturation
 smax = max_supersaturation(y0, args, ts)
 grad_smax = jax.grad(max_supersaturation, argnums=(0, 1))(y0, args, ts)
@@ -228,7 +238,111 @@ grad_nd = jax.grad(nd_from_parcel, argnums=(0, 1))(y0, args, t_end)
 ```
 
 The `ts` array passed to `max_supersaturation` must span the supersaturation
-peak; a conservative choice is `ts = jnp.linspace(0, t_end, n_output)`.
+peak; see [Differentiable $S_\text{max}$](#differentiable-s_max-dense-interpolation-and-newton-refinement)
+below for guidance on sizing and scaling `ts`.
+
+---
+
+## Differentiable $S_\text{max}$: dense interpolation and Newton refinement
+
+Computing a gradient-accurate $S_\text{max}$ requires more than returning
+`jnp.max(sol.ys[:, 6])`. The adaptive solver takes slightly different internal
+step structures for slightly different parameter values (especially updraft
+speed $V$). With a discrete output grid, the argmax occasionally jumps by one
+time step as $V$ varies, producing an aliased, non-monotone $S_\text{max}(V)$
+curve with alternating-sign gradient kinks of $\sim 10^{-3}$ relative
+amplitude. Quadratic correction at the argmax is roughly $10^3$ times too
+small to close this gap.
+
+`max_supersaturation` eliminates the aliasing with a three-stage peak-finding
+procedure on the solver's continuous **Hermite polynomial interpolant**
+(`SaveAt(dense=True)`).
+
+### Stage 1 — coarse bracket on the dense solution
+
+The solve stores a full piecewise-polynomial interpolant $\widetilde{S}(t)$
+over the integration interval rather than a discrete trajectory. The
+caller-supplied `ts` is used only as a *probe array* to locate the approximate
+peak bin:
+
+$$
+i^\ast = \operatorname{argmax}_{j}\, \widetilde{S}(t_j), \qquad
+t_j \in \mathbf{ts}
+$$
+
+$i^\ast$ is `stop_gradient`'d and used solely to define the bracket
+$[t_{i^\ast - 1},\, t_{i^\ast + 1}]$.
+
+### Stage 2 — fine-grid refinement
+
+Within that two-cell bracket, $N_\text{refine} = 64$ equally-spaced
+evaluations of the same continuous interpolant narrow the bracket to
+$2\,\Delta t / N_\text{refine}$. For a 600-point output grid spanning 1500 s,
+this is $\lesssim 0.09$ s.
+
+### Stage 3 — Newton correction
+
+One Newton step using the exact ODE right-hand side for $dS/dt$ and
+second-order finite differences for $d^2S/dt^2$ from the fine grid drives the
+peak-time residual to near machine precision:
+
+$$
+t_\text{peak} \leftarrow t_\text{fine} - \frac{(dS/dt)\big|_{t_\text{fine}}}{(d^2S/dt^2)\big|_{t_\text{fine}}}
+$$
+
+where $(dS/dt)|_t = \mathbf{f}(t, \mathbf{y}(t), \boldsymbol{\theta})[6]$ is
+read directly from `parcel_ode_sys` (exact, not finite-differenced). All three
+stages operate entirely under `jax.lax.stop_gradient`.
+
+### Why `stop_gradient` on $t_\text{peak}$ is exact
+
+Treating $t_\text{peak}$ as a non-differentiable constant is not an
+approximation. By the **envelope theorem**, at a smooth interior maximum
+
+$$
+\frac{dS_\text{max}}{d\theta} = \frac{\partial S}{\partial \theta}\bigg|_{t_\text{peak}}
+$$
+
+the implicit dependence of $t_\text{peak}$ on $\theta$ drops out identically.
+Gradient flows correctly through the diffrax adjoint from the single
+`sol.evaluate(t_peak)` call, with no contribution from the bracket-finding
+logic.
+
+### Output-grid sizing and $t_\text{end}$ scaling
+
+Because the dense interpolant is evaluated at `ts` only for the coarse bracket,
+the grid need not be fine — it must only be dense enough to contain the
+supersaturation peak.
+
+**Rule 1 — ensure the peak lies in the interior.** `ts[-1]` must extend past
+$S_\text{max}$ with at least one grid point beyond the peak. For a parcel
+ascending from cloud base, the peak occurs at altitude
+$z \approx z_0 + V \cdot t_\text{peak}$. A robust horizon choice is
+
+$$
+t_\text{end} \approx \frac{1500\,\text{m}}{V},
+\qquad \text{clamped to } [200\,\text{s},\, 15000\,\text{s}]
+$$
+
+which guarantees the solver reaches $\sim 1500$ m above cloud base regardless
+of updraft speed.
+
+**Rule 2 — fix the array shape across $V$ for JIT reuse.** All calls with the
+same `ts.shape[0]` reuse the same compiled XLA kernel. Scale only `t_end` with
+$V$, keeping the number of output points constant:
+
+```python
+_N_TS = 600  # fixed; triggers one JIT compilation
+
+def ts_for_V(V: float) -> jnp.ndarray:
+    t_end = max(200.0, min(1500.0 / V, 15000.0))
+    return jnp.linspace(0.0, t_end, _N_TS)
+```
+
+**Rule 3 — `t_end(V)` does not bias the adjoint.** Because $S_\text{max}$ is
+at an interior maximum, the envelope theorem also gives
+$\partial S_\text{max}/\partial t_\text{end} = 0$, so the $t_\text{end} \propto
+1/V$ coupling introduces no gradient error.
 
 ---
 

--- a/examples/sensitivity_sweep.py
+++ b/examples/sensitivity_sweep.py
@@ -397,51 +397,51 @@ def _plot(data: dict, path: str) -> None:
 
     # --- Global colour limits -------------------------------------------------
 
-    all_grad = np.concatenate([
-        arr[np.isfinite(arr)]
-        for rdef in row_defs
-        for arr in (rdef["exact"], rdef["num"])
-    ])
+    all_grad = np.concatenate(
+        [arr[np.isfinite(arr)] for rdef in row_defs for arr in (rdef["exact"], rdef["num"])]
+    )
     grad_vmax = float(np.nanpercentile(np.abs(all_grad), 98))
     grad_norm = mcolors.Normalize(vmin=0, vmax=grad_vmax)
 
-    all_err = np.concatenate([
-        (rdef["exact"] - rdef["num"])[
-            np.isfinite(rdef["exact"]) & np.isfinite(rdef["num"])
+    all_err = np.concatenate(
+        [
+            (rdef["exact"] - rdef["num"])[np.isfinite(rdef["exact"]) & np.isfinite(rdef["num"])]
+            for rdef in row_defs
         ]
-        for rdef in row_defs
-    ])
+    )
     err_vlim = max(float(np.nanpercentile(np.abs(all_err), 98)), 1e-10)
     err_norm = mcolors.TwoSlopeNorm(vmin=-err_vlim, vcenter=0.0, vmax=err_vlim)
 
     # --- Font sizes -----------------------------------------------------------
-    FS_TICK  = 11
+    FS_TICK = 11
     FS_LABEL = 13
     FS_TITLE = 11
 
     # --- Layout: 3×4 [exact | num | gap | error]; colorbars below as h-bars --
     fig = plt.figure(figsize=(13, 10))
     gs = GridSpec(
-        3, 4,
+        3,
+        4,
         figure=fig,
         hspace=0.28,
         wspace=0.12,
         width_ratios=[10, 10, 1.5, 8],
-        left=0.09, right=0.95, top=0.93, bottom=0.22,
+        left=0.09,
+        right=0.95,
+        top=0.93,
+        bottom=0.22,
     )
-    plot_axes = np.array(
-        [[fig.add_subplot(gs[i, j]) for j in (0, 1, 3)] for i in range(3)]
-    )
+    plot_axes = np.array([[fig.add_subplot(gs[i, j]) for j in (0, 1, 3)] for i in range(3)])
 
     # Horizontal colorbars: derive position from the numerical column bbox.
     pos_num = gs[0, 1].get_position(fig)
     cbar_cx = (pos_num.x0 + pos_num.x1) / 2
-    cbar_w  = (pos_num.x1 - pos_num.x0) * 1.4   # column width + 40%
+    cbar_w = (pos_num.x1 - pos_num.x0) * 1.4  # column width + 40%
     cbar_x0 = cbar_cx - cbar_w / 2
-    cbar_h  = 0.028
+    cbar_h = 0.028
 
     cax_grad = fig.add_axes([cbar_x0, 0.13, cbar_w, cbar_h])  # above
-    cax_err  = fig.add_axes([cbar_x0, 0.05, cbar_w, cbar_h])  # below
+    cax_err = fig.add_axes([cbar_x0, 0.05, cbar_w, cbar_h])  # below
 
     col_titles = [
         "Exact adjoint  (jax.grad)",
@@ -450,21 +450,23 @@ def _plot(data: dict, path: str) -> None:
     ]
 
     # Tick positions: explicit decimals, minor ticks suppressed.
-    x_ticks = [t for t in [0.1, 0.2, 0.5, 1, 2, 3]
-                if V_grid.min() * 0.99 <= t <= V_grid.max() * 1.01]
-    y_ticks = [t for t in [0.02, 0.03, 0.05, 0.1, 0.2, 0.3]
-                if mu_grid.min() * 0.99 <= t <= mu_grid.max() * 1.01]
+    x_ticks = [
+        t for t in [0.1, 0.2, 0.5, 1, 2, 3] if V_grid.min() * 0.99 <= t <= V_grid.max() * 1.01
+    ]
+    y_ticks = [
+        t
+        for t in [0.02, 0.03, 0.05, 0.1, 0.2, 0.3]
+        if mu_grid.min() * 0.99 <= t <= mu_grid.max() * 1.01
+    ]
     dec_fmt = FuncFormatter(lambda x, _: f"{x:g}")
 
     for i_row, rdef in enumerate(row_defs):
         exact = rdef["exact"]
-        num   = rdef["num"]
-        err   = np.where(np.isfinite(exact) & np.isfinite(num), exact - num, np.nan)
+        num = rdef["num"]
+        err = np.where(np.isfinite(exact) & np.isfinite(num), exact - num, np.nan)
 
         for i_col, (arr, norm, cmap) in enumerate(
-            [(exact, grad_norm, "plasma"),
-             (num,   grad_norm, "plasma"),
-             (err,   err_norm,  "RdBu_r")]
+            [(exact, grad_norm, "plasma"), (num, grad_norm, "plasma"), (err, err_norm, "RdBu_r")]
         ):
             ax = plot_axes[i_row, i_col]
             ax.pcolormesh(V_grid, mu_grid, arr.T, cmap=cmap, norm=norm, shading="auto")
@@ -487,8 +489,7 @@ def _plot(data: dict, path: str) -> None:
             if i_col == 0:
                 ax.yaxis.set_major_locator(FixedLocator(y_ticks))
                 ax.yaxis.set_major_formatter(dec_fmt)
-                ax.set_ylabel(rdef["label"] + "\n$\\mu$ (µm)",
-                              fontsize=FS_LABEL, labelpad=4)
+                ax.set_ylabel(rdef["label"] + "\n$\\mu$ (µm)", fontsize=FS_LABEL, labelpad=4)
             else:
                 ax.tick_params(axis="y", labelleft=False)
 
@@ -497,7 +498,8 @@ def _plot(data: dict, path: str) -> None:
     cbar_grad = fig.colorbar(sm_grad, cax=cax_grad, orientation="horizontal")
     cbar_grad.set_label(
         r"$\partial S_{\mathrm{max}}/\partial V$  (% (m s$^{-1}$)$^{-1}$)",
-        fontsize=FS_LABEL - 1, labelpad=5,
+        fontsize=FS_LABEL - 1,
+        labelpad=5,
     )
     cbar_grad.ax.tick_params(labelsize=FS_TICK)
 
@@ -505,7 +507,8 @@ def _plot(data: dict, path: str) -> None:
     cbar_err = fig.colorbar(sm_err, cax=cax_err, orientation="horizontal")
     cbar_err.set_label(
         r"$\Delta\,\partial S_{\mathrm{max}}/\partial V$  (% (m s$^{-1}$)$^{-1}$)",
-        fontsize=FS_LABEL - 1, labelpad=5,
+        fontsize=FS_LABEL - 1,
+        labelpad=5,
     )
     cbar_err.ax.tick_params(labelsize=FS_TICK)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,31 +99,32 @@ hooks:
 nav:
   - Home: index.md
   - Getting Started:
-    - Installation: getting_started/installation.md
-    - Quick Start: getting_started/quickstart.md
+      - Installation: getting_started/installation.md
+      - Quick Start: getting_started/quickstart.md
   - User Guide:
-    - Scientific Description: user_guide/sci_descr.md
-    - Migration Guide (v1→v2): user_guide/migration.md
-    - Numerical Methods: user_guide/numerical_methods.md
-    - GPU Setup: user_guide/gpu.md
+      - Scientific Description: user_guide/sci_descr.md
+      - Migration Guide (v1→v2): user_guide/migration.md
+      - Numerical Methods: user_guide/numerical_methods.md
+      - Best Practices: user_guide/best_practices.md
+      - GPU Setup: user_guide/gpu.md
   - Examples:
-    - Basic Run: examples/basic_run.md
-    - Live Integration: examples/live_run.md
-    - Updraft Ensemble: examples/updraft_ensemble.md
-    - Sensitivity Analysis: examples/differentiable_smax.md
-    - Activation Comparison: examples/activation_comparison.md
-    - Sensitivity Sweep: examples/sensitivity_sweep.md
+      - Basic Run: examples/basic_run.md
+      - Live Integration: examples/live_run.md
+      - Updraft Ensemble: examples/updraft_ensemble.md
+      - Sensitivity Analysis: examples/differentiable_smax.md
+      - Activation Comparison: examples/activation_comparison.md
+      - Sensitivity Sweep: examples/sensitivity_sweep.md
   - API Reference:
-    - Core:
-      - ParcelModel: api/model.md
-      - ModelOutput: api/model_output.md
-    - Aerosol Population:
-      - AerosolSpecies: api/aerosol.md
-      - Distributions: api/distributions.md
-    - Activation: api/activation.md
-    - Updraft: api/updraft.md
-    - Ensemble: api/ensemble.md
-    - Advanced:
-      - Integrator: api/integrator.md
-      - Equilibrate: api/equilibrate.md
-      - Thermodynamics: api/thermo.md
+      - Core:
+          - ParcelModel: api/model.md
+          - ModelOutput: api/model_output.md
+      - Aerosol Population:
+          - AerosolSpecies: api/aerosol.md
+          - Distributions: api/distributions.md
+      - Activation: api/activation.md
+      - Updraft: api/updraft.md
+      - Ensemble: api/ensemble.md
+      - Advanced:
+          - Integrator: api/integrator.md
+          - Equilibrate: api/equilibrate.md
+          - Thermodynamics: api/thermo.md

--- a/pyrcel/integrator.py
+++ b/pyrcel/integrator.py
@@ -187,6 +187,130 @@ _S_IDX = 6
 _N_REFINE = 64  # dense evaluations within the peak bracket for sub-grid accuracy
 
 
+def _peak_from_trajectory(
+    ts: np.ndarray, ys: np.ndarray, args: tuple
+) -> tuple[float, float, np.ndarray]:
+    """Find S_max from a saved trajectory via Hermite cubic interpolation.
+
+    Constructs cubic Hermite polynomials over the two sub-intervals bracketing
+    the coarse argmax.  The ODE right-hand side supplies exact endpoint
+    derivatives — the same polynomial family that diffrax uses for its
+    ``SaveAt(dense=True)`` interpolant — applied post-hoc to the saved discrete
+    output without a second solve.
+
+    The cubic Hermite on ``[t0, t1]`` parameterised by ``u = (t-t0)/h``:
+
+    .. math::
+
+        p(u) = (2u^3-3u^2+1)S_0 + (-2u^3+3u^2)S_1
+               + h(u^3-2u^2+u)\\dot{S}_0 + h(u^3-u^2)\\dot{S}_1
+
+    The peak time is found analytically by solving ``dp/du = 0`` (a quadratic
+    in ``u``) over both sub-intervals and returning the larger interior maximum.
+
+    Cost: 3 ODE RHS evaluations; no second ODE solve.
+
+    Parameters
+    ----------
+    ts : ndarray, shape ``(n,)``
+        Output times (monotonically increasing).
+    ys : ndarray, shape ``(n, 7 + nr)``
+        State trajectory at those times.
+    args : tuple
+        ``(r_drys, Nis, kappas, accom, V)`` forwarded to ``parcel_ode_sys``.
+
+    Returns
+    -------
+    smax : float
+        Refined peak supersaturation.
+    t_smax : float
+        Refined peak time (s).
+    y_argmax : ndarray, shape ``(7 + nr,)``
+        State at the coarse argmax index (used for ``z_smax`` / activation).
+    """
+    ts_a = np.asarray(ts)
+    ys_a = np.asarray(ys)
+    S = ys_a[:, _S_IDX]
+    n = len(ts_a)
+    if n < 3:
+        si = int(np.argmax(S))
+        return float(S[si]), float(ts_a[si]), ys_a[si]
+    si = int(np.clip(np.argmax(S), 1, n - 2))
+
+    # ODE RHS at the three bracket points — exact derivatives, no finite differences.
+    # Same information diffrax stores per solver step for its dense interpolant.
+    def _f_at(i: int) -> Array:
+        return parcel_ode_sys(float(ts_a[i]), jnp.asarray(ys_a[i]), args)
+
+    f_m, f_c, f_p = _f_at(si - 1), _f_at(si), _f_at(si + 1)
+    dS_m = float(f_m[_S_IDX])
+    dS_c = float(f_c[_S_IDX])
+    dS_p = float(f_p[_S_IDX])
+    t_m, t_c, t_p = float(ts_a[si - 1]), float(ts_a[si]), float(ts_a[si + 1])
+
+    # Build cubic Hermite interpolants over each sub-interval using diffrax's
+    # built-in class — the same polynomial family as SaveAt(dense=True).
+    # NOTE: ThirdOrderHermitePolynomialInterpolation expects k0, k1 as
+    # dp/du (normalized slopes), i.e. k = h * dy/dt, not dy/dt itself.
+    def _make_interp(
+        i0: int, i1: int, f0: Array, f1: Array
+    ) -> dfx.ThirdOrderHermitePolynomialInterpolation:
+        h = float(ts_a[i1]) - float(ts_a[i0])
+        return dfx.ThirdOrderHermitePolynomialInterpolation(
+            t0=float(ts_a[i0]),
+            t1=float(ts_a[i1]),
+            y0=jnp.asarray(ys_a[i0]),
+            y1=jnp.asarray(ys_a[i1]),
+            k0=h * f0,
+            k1=h * f1,
+        )
+
+    def _hermite_peak(
+        interp: dfx.ThirdOrderHermitePolynomialInterpolation, dS0: float, dS1: float
+    ) -> tuple[float, float] | None:
+        """Peak of the cubic Hermite on the open interval (t0, t1), or None.
+
+        dS0, dS1 are the ODE dS/dt values at the endpoints, passed explicitly
+        to avoid the jax.jvp cost of interp.derivative().
+        """
+        t0, t1 = float(interp.t0), float(interp.t1)
+        h = t1 - t0
+        S0 = float(interp.evaluate(t0)[_S_IDX])
+        S1 = float(interp.evaluate(t1)[_S_IDX])
+        # dp/du = A·u² + B·u + C  (derivative of the cubic w.r.t. normalised u)
+        A = 6.0 * (S0 - S1) / h + 3.0 * (dS0 + dS1)
+        B = 6.0 * (S1 - S0) / h - 2.0 * (2.0 * dS0 + dS1)
+        C = dS0
+        if abs(A) < 1e-30:
+            u_roots = (-C / B,) if abs(B) > 1e-30 else ()
+        else:
+            disc = B * B - 4.0 * A * C
+            if disc < 0.0:
+                return None
+            sq = disc**0.5
+            u_roots = ((-B + sq) / (2.0 * A), (-B - sq) / (2.0 * A))
+        best: tuple[float, float] | None = None
+        for u in u_roots:
+            if not 0.0 < u < 1.0:
+                continue
+            if 2.0 * A * u + B >= 0.0:  # d²p/du² ≥ 0 → local minimum, skip
+                continue
+            S_pk = float(interp.evaluate(t0 + u * h)[_S_IDX])
+            if best is None or S_pk > best[0]:
+                best = (S_pk, t0 + u * h)
+        return best
+
+    r1 = _hermite_peak(_make_interp(si - 1, si, f_m, f_c), dS_m, dS_c)
+    r2 = _hermite_peak(_make_interp(si, si + 1, f_c, f_p), dS_c, dS_p)
+    candidates = [r for r in (r1, r2) if r is not None]
+    if candidates:
+        smax, t_smax = max(candidates, key=lambda x: x[0])
+    else:
+        smax, t_smax = float(S[si]), t_c
+
+    return float(smax), float(t_smax), ys_a[si]
+
+
 def max_supersaturation(
     y0: ArrayLike,
     args: tuple,

--- a/pyrcel/integrator.py
+++ b/pyrcel/integrator.py
@@ -235,7 +235,8 @@ def _peak_from_trajectory(
     if n < 3:
         si = int(np.argmax(S))
         return float(S[si]), float(ts_a[si]), ys_a[si]
-    si = int(np.clip(np.argmax(S), 1, n - 2))
+    si_raw = int(np.argmax(S))
+    si = int(np.clip(si_raw, 1, n - 2))
 
     # ODE RHS at the three bracket points — exact derivatives, no finite differences.
     # Same information diffrax stores per solver step for its dense interpolant.
@@ -246,7 +247,6 @@ def _peak_from_trajectory(
     dS_m = float(f_m[_S_IDX])
     dS_c = float(f_c[_S_IDX])
     dS_p = float(f_p[_S_IDX])
-    t_m, t_c, t_p = float(ts_a[si - 1]), float(ts_a[si]), float(ts_a[si + 1])
 
     # Build cubic Hermite interpolants over each sub-interval using diffrax's
     # built-in class — the same polynomial family as SaveAt(dense=True).
@@ -306,9 +306,12 @@ def _peak_from_trajectory(
     if candidates:
         smax, t_smax = max(candidates, key=lambda x: x[0])
     else:
-        smax, t_smax = float(S[si]), t_c
+        # No interior peak found on either sub-interval (e.g. maximum lies exactly
+        # on a grid point or at a trajectory boundary).  Fall back to the raw grid
+        # maximum so boundary cases (si_raw != si) are handled correctly.
+        smax, t_smax = float(S[si_raw]), float(ts_a[si_raw])
 
-    return float(smax), float(t_smax), ys_a[si]
+    return float(smax), float(t_smax), ys_a[si_raw]
 
 
 def max_supersaturation(

--- a/pyrcel/model.py
+++ b/pyrcel/model.py
@@ -325,20 +325,23 @@ class ParcelModel:
                     live_printer.finish()
                 ts, ys = np.asarray(ts), np.asarray(ys)
                 if not terminate:
-                    # Post-hoc S_max from the saved trajectory: 3-point quadratic
-                    # interpolation + one Newton step using the ODE RHS.  No second
-                    # ODE solve — two RHS evaluations are enough for near-machine-
-                    # precision accuracy (same approach as max_supersaturation Stage 3).
-                    smax, t_smax_f, y_smax = _peak_from_trajectory(ts, ys, self.args)
+                    # Post-hoc S_max from the saved trajectory via Hermite cubic
+                    # interpolation — no second ODE solve required.
+                    smax, t_smax_f, _ = _peak_from_trajectory(ts, ys, self.args)
                     activated = True
                     peak = (smax, t_smax_f)
+                    # Height at the refined peak time via linear interpolation of
+                    # the saved trajectory (more accurate than the coarse-grid state).
+                    z_smax = float(np.interp(t_smax_f, ts, ys[:, c.STATE_VAR_MAP["z"]]))
+                else:
+                    z_smax = float("nan")
                 run_info = {
                     "success": success,
                     "activated": activated,
                     "t_smax": t_smax_f,
                     "smax": smax,
                     "t_cutoff": float(ts[-1]) if len(ts) else t_final,
-                    "z_smax": float(y_smax[0]) if y_smax is not None else float("nan"),
+                    "z_smax": z_smax,
                     "z_end": float(ys[-1, c.STATE_VAR_MAP["z"]]) if len(ys) else float("nan"),
                 }
             elif terminate:
@@ -413,14 +416,12 @@ class ParcelModel:
     def _compute_summary(self, peak: object = None) -> dict:
         assert self.x is not None
         assert self.time is not None
-        S = self.x[:, c.STATE_VAR_MAP["S"]]
         if peak is not None:
             # Event-localized or caller-supplied precise S_max/t_smax.
             S_max, t_smax = float(peak[0]), float(peak[1])
             si = int(np.argmin(np.abs(self.time - t_smax)))
         else:
-            # Quadratic interpolation + Newton step on the saved trajectory —
-            # same accuracy as the live-path post-hoc finder, no second solve.
+            # Post-hoc Hermite cubic peak finder — no second solve.
             S_max, t_smax, _ = _peak_from_trajectory(self.time, self.x, self.args)
             si = int(np.argmin(np.abs(self.time - t_smax)))
         T_smax = float(self.x[si, c.STATE_VAR_MAP["T"]])

--- a/pyrcel/model.py
+++ b/pyrcel/model.py
@@ -42,6 +42,7 @@ from .console_report import (
 from .equilibrate import equilibrate_initial_state
 from .integrator import (
     STATE_RTOL,
+    _peak_from_trajectory,
     find_smax,
     integrate_parcel,
     integrate_parcel_chunked,
@@ -323,6 +324,14 @@ class ParcelModel:
                 if live_printer is not None:
                     live_printer.finish()
                 ts, ys = np.asarray(ts), np.asarray(ys)
+                if not terminate:
+                    # Post-hoc S_max from the saved trajectory: 3-point quadratic
+                    # interpolation + one Newton step using the ODE RHS.  No second
+                    # ODE solve — two RHS evaluations are enough for near-machine-
+                    # precision accuracy (same approach as max_supersaturation Stage 3).
+                    smax, t_smax_f, y_smax = _peak_from_trajectory(ts, ys, self.args)
+                    activated = True
+                    peak = (smax, t_smax_f)
                 run_info = {
                     "success": success,
                     "activated": activated,
@@ -406,14 +415,14 @@ class ParcelModel:
         assert self.time is not None
         S = self.x[:, c.STATE_VAR_MAP["S"]]
         if peak is not None:
-            # Use the event-localized (precise) S_max/t_smax; take droplet radii from
-            # the nearest output sample for the activation diagnostics.
+            # Event-localized or caller-supplied precise S_max/t_smax.
             S_max, t_smax = float(peak[0]), float(peak[1])
             si = int(np.argmin(np.abs(self.time - t_smax)))
         else:
-            si = int(np.argmax(S))
-            S_max = float(S[si])
-            t_smax = float(self.time[si])
+            # Quadratic interpolation + Newton step on the saved trajectory —
+            # same accuracy as the live-path post-hoc finder, no second solve.
+            S_max, t_smax, _ = _peak_from_trajectory(self.time, self.x, self.args)
+            si = int(np.argmin(np.abs(self.time - t_smax)))
         T_smax = float(self.x[si, c.STATE_VAR_MAP["T"]])
         rs_smax = self.x[si, c.N_STATE_VARS :]
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `ParcelModel.run(live=True, terminate=False)` was returning `S_max = nan` because the smax variable was initialised to `float("nan")` and never overwritten when the termination event was disabled.
- **New `_peak_from_trajectory` function**: Post-hoc peak finder that avoids a second ODE solve entirely. Constructs two `dfx.ThirdOrderHermitePolynomialInterpolation` polynomials over the sub-intervals bracketing the discrete argmax, evaluates exact endpoint derivatives via three eager `parcel_ode_sys` calls, and finds the analytic maximum by solving dp/du = 0 (quadratic in u). Cost: 3 RHS evaluations; accuracy: O(Δt⁴).
- **Non-live path improved**: `_compute_summary` (when no event-localised peak is available) previously used the raw coarse-grid argmax — now calls `_peak_from_trajectory` for O(Δt⁴) accuracy at no extra cost.
- **Docs consolidation**: `numerical_methods.md` gains a section on the Hermite interpolation algorithm; `basic_run.md`, `index.md`, `mkdocs.yml`, and `best_practices.md` updated.

## Key technical note

`dfx.ThirdOrderHermitePolynomialInterpolation` expects `k = h · dy/dt` as slope inputs (derivative w.r.t. the normalised parameter u, not w.r.t. time). The `_make_interp` helper scales by h accordingly. This matches how diffrax internally stores stages for `SaveAt(dense=True)` dense output.

## Test plan

- [ ] `run(live=True, terminate=False)` no longer returns `nan` for S_max
- [ ] live and non-live paths agree to O(Δt⁴) precision (confirmed: both give 0.26904% at dt=10s; dt=1s gives 0.26911%)
- [ ] `run(terminate=True)` unaffected (uses existing event-localized path)
- [ ] `run(live=False, terminate=False)` summary now uses Hermite peak rather than raw argmax
- [ ] `uv run pytest tests/ -m "not slow"` passes

## Related

- Closes / tracks #79 (future `max_supersaturation` single-solve refactor using same Hermite approach inside JAX JIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect interactive summary diagnostics and post-hoc peak finding on saved trajectories; event-based termination and the JAX differentiable path are largely unchanged aside from shared helper reuse.
> 
> **Overview**
> Fixes **`ParcelModel.run(live=True, terminate=False)`** leaving **`S_max` as NaN** by computing peak supersaturation from the saved trajectory after the chunked integration finishes.
> 
> Adds **`_peak_from_trajectory`** in `pyrcel/integrator.py`: brackets the discrete argmax, builds **`diffrax.ThirdOrderHermitePolynomialInterpolation`** on the two adjacent intervals (endpoint slopes from three **`parcel_ode_sys`** RHS calls, with **`k = h·dy/dt`**), and locates the interior maximum by solving **`dp/du = 0`**—no second ODE solve.
> 
> **`ParcelModel`** calls this helper on the live path when **`terminate=False`**, and **`_compute_summary`** uses it whenever no event-localized **`peak`** is passed (replacing the coarse-grid argmax).
> 
> Documentation updates: v2.0 warnings and refreshed examples in **README** / **`docs/index.md`**, Hermite post-hoc and differentiable **`max_supersaturation`** detail in **`numerical_methods.md`**, new **`best_practices.md`**, nav fixes in **`mkdocs.yml`**, and minor formatting in **`sensitivity_sweep.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b797ed324bee637a25bc48fd18d329faf55cc5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->